### PR TITLE
Add pdf generation and schneider updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update -q=2 && \
         python3-pip \
         python3-setuptools \
         python3-wheel \
-        python3-yaml
+        python3-yaml \
+        wkhtmltopdf
 
 WORKDIR /squad_client
 COPY . ./

--- a/examples/schneider_report.py
+++ b/examples/schneider_report.py
@@ -24,3 +24,8 @@ template = templateEnv.get_template(TEMPLATE_FILE)
 outputText = template.render(group=group, project=project, build=build, testruns=testruns)
 with open('schneider_generated_report.html', 'w') as reportFile:
     reportFile.write(outputText)
+if os.getenv('TO_PDF'):
+    bash_cmd = "wkhtmltopdf schneider_generated_report.html schneider_generated_report.pdf"
+    import subprocess
+    process = subprocess.Popen(bash_cmd.split(), stdout=subprocess.PIPE)
+    output, error = process.communicate()

--- a/examples/schneider_template.html
+++ b/examples/schneider_template.html
@@ -26,6 +26,22 @@
                             <th scope="row">build location</th>
                             <td>{{ build.metadata.build_location }}</td>
                         </tr>
+			<tr>
+				<th scope="row">Total Pass Summary</th>
+				<td>{{ build.total_pass_summary }}</tr>
+			</tr>
+			<tr>
+				<th scope="row">Total Fail Summary</th>
+				<td>{{ build.total_fail_summary }}</tr>
+			</tr>
+			<tr>
+				<th scope="row">Total Skip Summary</th>
+				<td>{{ build.total_skip_summary }}</tr>
+			</tr>
+			<tr>
+				<th scope="row">Total Xfail Summary</th>
+				<td>{{ build.total_xfail_summary }}</tr>
+			</tr>
                     </table>
                 </div>
             </div>
@@ -36,11 +52,11 @@
                     <table class="table">
                         <tr>
                             <th scope="row">Job</th>
-                            <td><a href="https://validation.linaro.org/scheduler/job/{{ testrun.job_id }}">Job url</a></td>
+			    <td><a href="https://validation.linaro.org/scheduler/job/{{ testrun.job_id }}">{{ testrun.id }}</a></td>
                         </tr>
                         <tr>
                             <th scope="row">Environment</th>
-                            <td>{{ testrun.environment.slug }}</td>
+			    <td>{{ testrun.environment.slug }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Tests</th>
@@ -58,7 +74,8 @@
                                                 <tbody>
                                                     {% for test in suite.tests %}
                                                     <tr>
-                                                        <td>{{ test.short_name }} ({{ test.status }})</td>
+                                                        <td class="col-10">{{ test.short_name }}</td>
+							<td class="col-2" style="background-color:{{'blue' if test.status == 'xfail' else 'red' if test.status == 'fail' else 'yellow' if test.status == 'skip'}}">{{ test.status }}</td>
                                                     </tr>
                                                     {% endfor %}
                                                 </tbody>
@@ -69,6 +86,22 @@
                                 </table>
                             </td>
                         </tr>
+			<tr>
+				<th scope="row">Total Pass</th>
+				<td>{{ testrun.total_pass }}</td>
+			</tr>
+			<tr>
+				<th scope="row">Total Fail</th>
+				<td>{{ testrun.total_fail }}</td>
+			</tr>
+			<tr>
+				<th scope="row">Total Skip</th>
+				<td>{{ testrun.total_skip }}</td>
+			</tr>
+			<tr>
+				<th scope="row">Total xfail</th>
+				<td>{{ testrun.total_xfail }}</td>
+			</tr>
                     </table>
                 </div>
                 <div class="spacer"></div>


### PR DESCRIPTION
Docker & examples: Add wkhtmltopdf to docker dependencies and update
schneider template and script to enable pdf generation and display tests
status totals and summary.