### PR TITLE
setup.py: make squad-client program name shorter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            'squad-client-manage=squad_client.manage:main',
+            'squad-client=squad_client.manage:main',
         ]
     },
     install_requires=requirements,


### PR DESCRIPTION
This changes `squad-client-manage` program name to `squad-client` only. It reads better.

PS: suggested by @danrue 