### PR TITLE
Fix the import paths for some docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ The output of this command should look similar to:
 More complex filtering and data retrieval are available. Here is an example of getting a specific build:
 
 ```python
-from squad_client.api import SquadApi
-from squad_client.models import Squad
+from squad_client.core.api import SquadApi
+from squad_client.core.models import Squad
 
 SquadApi.configure(url='https://qa-reports.linaro.org/')
 

--- a/examples/example_report.py
+++ b/examples/example_report.py
@@ -7,8 +7,8 @@ import sys
 sys.path.append('..')
 
 
-from squad_client.api import SquadApi
-from squad_client.models import Squad
+from squad_client.core.api import SquadApi
+from squad_client.core.models import Squad
 
 
 # Configure SQUAD url


### PR DESCRIPTION
Some of the docs and examples have incorrect import paths (missing `core`).

Fixes #24 .