### PR TITLE
manage: make squad-host mandatory in environment

### DIFF
--- a/squad_client/manage.py
+++ b/squad_client/manage.py
@@ -18,7 +18,7 @@ def main():
 
     parser = argparse.ArgumentParser(prog='./manage.py')
     parser.add_argument('--debug', action='store_true', help='display debug messages')
-    parser.add_argument('--squad-host', help='SQUAD host, example: https://qa-reports.linaro.org', required=True)
+    parser.add_argument('--squad-host', help='SQUAD host, example: https://qa-reports.linaro.org')
     parser.add_argument('--squad-token', help='SQUAD authentication token')
     subparser = parser.add_subparsers(help='available subcommands', dest='command')
 
@@ -29,9 +29,13 @@ def main():
         parser.print_help()
         return -1
 
+    squad_host = args.squad_host or os.getenv('SQUAD_HOST')
+    squad_token = args.squad_token or os.getenv('SQUAD_TOKEN')
+    if squad_host is None:
+        logger.error('Either --squad-host or SQUAD_HOST env variable are required')
+        return -1
+
     try:
-        squad_host = args.squad_host or os.getenv('SQUAD_HOST')
-        squad_token = args.squad_token or os.getenv('SQUAD_TOKEN')
         SquadApi.configure(squad_host, token=squad_token)
     except ApiException as e:
         logger.error('Failed to configure squad api: %s' % e)


### PR DESCRIPTION
It was already mandatory, but only in command line, now it checks if env variable is set as well.