### PR TITLE
manage: add basic caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 dist/
 *.egg-info/
 *.sqlite3
+squad_client_cache.sqlite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
+requests_cache
 jinja2
 ipython
 pyyaml

--- a/squad_client/manage.py
+++ b/squad_client/manage.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import os
+import requests_cache
 import sys
 
 
@@ -24,6 +25,7 @@ def main():
     parser.add_argument('--debug', action='store_true', help='display debug messages')
     parser.add_argument('--squad-host', help='SQUAD host, example: https://qa-reports.linaro.org')
     parser.add_argument('--squad-token', help='SQUAD authentication token')
+    parser.add_argument('--cache', default=0, help='Cache API results for N number of seconds. Disabled by default.')
     subparser = parser.add_subparsers(help='available subcommands', dest='command')
 
     SquadClientCommand.add_commands(subparser)
@@ -44,6 +46,10 @@ def main():
     except ApiException as e:
         logger.error('Failed to configure squad api: %s' % e)
         return -1
+
+    if args.cache > 0:
+        logger.debug('Caching results in "squad_client_cache.sqlite" for %d seconds' % args.cache)
+        requests_cache.install_cache('squad_client_cache', expire_after=args.cache)
 
     rc = SquadClientCommand.process(args)
     return 1 if rc is False else 0 if rc is True else -1


### PR DESCRIPTION
Fixes https://github.com/Linaro/squad-client/issues/4

This uses `requests_cache`, a small caching library that will blindly cache contens coming from requests library.

Running a simple test case
```bash
./manage.py shell examples/build_report.py --script-params "--squad-host http://localhost:8000 --group lkft --project linux-stable-rc-4.14-oe --build v4.14.74 --token $SQUAD_TOKEN --template examples/build_report_template.html --output generated.html"
```

I got 690 requests without caching and 484 with cache on