### PR TITLE
core: models: query tests in Suite class

### DIFF
--- a/squad_client/shortcuts.py
+++ b/squad_client/shortcuts.py
@@ -29,7 +29,7 @@ def retrieve_build_results(build_url):
             testrun = testruns[_id]
             test_suites = {}
             for suite in testrun.test_suites:
-                test_suites[suite.name] = {t.short_name: t.status for t in suite.tests.values()}
+                test_suites[suite.name] = {t.short_name: t.status for t in suite.tests().values()}
 
             metric_suites = {}
             for suite in testrun.metric_suites:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -185,3 +185,16 @@ class GroupTest(unittest.TestCase):
 
         p = first(check_project)
         p.delete()
+
+
+class SuiteTest(unittest.TestCase):
+
+    def setUp(self):
+        self.suite = first(Squad().suites(slug='my_suite'))
+
+    def test_basic(self):
+        self.assertTrue(self.suite is not None)
+
+    def test_suite_tests(self):
+        tests = self.suite.tests()
+        self.assertEqual(4, len(tests))


### PR DESCRIPTION
Now one can get all tests belonging to a Suite. Although that's probably a huge test set, it shouldn't time out the backend server.

It won't timeout backend after https://github.com/Linaro/squad/pull/745 is merged and rolled out