### PR TITLE
examples: fix suite retrieval in build_report.py

### DIFF
--- a/examples/build_report.py
+++ b/examples/build_report.py
@@ -55,7 +55,7 @@ project = group.project(args.project)
 build = project.build(args.build)
 
 squad_envs = Squad().environments(project=project.id)
-squad_suites = Squad().suites(project=project.id)
+squad_suites = Squad().suites(project=project.id, count=-1)
 envs = {}
 envs_summaries = {}
 testruns = {}


### PR DESCRIPTION
By default max of 50 suites were retrieved. This leads to errors if the
tests from the build were included in the suite that is further down the
list. This patch retrieves all suites belonging to the project and fixes
the issue.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>