### PR TITLE
Allow the verbose flag to be used when running specific tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,8 +11,12 @@ def run(coverage=False, tests=['discover'], verbose=False):
         return False
 
     argv = ['-m', 'unittest'] + tests
-    if len(tests) == 0 and verbose:
-        argv += ['discover', '-v']
+
+    if len(tests) == 0:
+        argv += ['discover']
+
+    if verbose:
+        argv += ['-v']
 
     if coverage:
         print('\t --coverage is enabled, run `coverage report -m` to view coverage report')


### PR DESCRIPTION
Verbose (`--verbose`) does not appear to work when running tests for a specific module.

example:
```
./manage.py --debug --squad-host http://localhost:9000 test -v tests.test_submit
[INFO] Running tests
[INFO] Starting a fresh squad instance on port 9000
[INFO] Creating database schema
[INFO] Applying tests/fixtures.py
..........
----------------------------------------------------------------------
Ran 10 tests in 19.093s

OK
[INFO] Terminating daemons
```

With this PR applied, verbose will work (ignore the failures, thats from some other changes):
```
./manage.py --squad-host http://localhost:9000 test -v tests.test_submit
[INFO] Running tests
[INFO] Starting a fresh squad instance on port 9000
[INFO] Creating database schema
[INFO] Applying tests/fixtures.py
test_submit (tests.test_submit.SquadSubmitTest) ... ok
test_submit_empty (tests.test_submit.SubmitCommandTest) ... ok
test_submit_everything (tests.test_submit.SubmitCommandTest) ... ok
test_submit_invalid_result_value (tests.test_submit.SubmitCommandTest) ... ok
test_submit_results_bad_extension (tests.test_submit.SubmitCommandTest) ... FAIL
test_submit_results_json (tests.test_submit.SubmitCommandTest) ... ok
test_submit_results_malformed_json (tests.test_submit.SubmitCommandTest) ... ok
test_submit_results_malformed_yaml (tests.test_submit.SubmitCommandTest) ... ok
test_submit_results_yaml (tests.test_submit.SubmitCommandTest) ... ok
test_submit_single_metric (tests.test_submit.SubmitCommandTest) ... ok
test_submit_single_test (tests.test_submit.SubmitCommandTest) ... ok

======================================================================
FAIL: test_submit_results_bad_extension (tests.test_submit.SubmitCommandTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/justin/GitHub/squad-client/tests/test_submit.py", line 168, in test_submit_results_bad_extension
    self.assertTrue(proc.ok)
AssertionError: False is not true

----------------------------------------------------------------------
Ran 11 tests in 21.154s

FAILED (failures=1)
[INFO] Terminating daemons
```