### PR TITLE
WIP: extract build version and environment (arch) from builds.json for tuxbuild

### DIFF
--- a/squad_client/commands/submit.py
+++ b/squad_client/commands/submit.py
@@ -11,30 +11,65 @@ logger = logging.getLogger()
 
 
 class SubmitCommand(SquadClientCommand):
+    """
+        The `squad-client submit` command is flexible enought to allow 3 types of result
+        submission:
+
+        1. The simplest one is by submitting single results. Ex (log, metadata and attachments are optional):
+
+            $ squad-client submit \
+                  --group mygroup \
+                  --project myproject \
+                  --build mybuild
+                  --environment myenv
+                  --result-name mysuite/mytest \
+                  --result-value pass \
+                  --logs name-of-test-log-file.log \
+                  --metadata name-of-test-metadata-file.json \
+                  --attachments attachment1.json attachment2.png attachment3.xml
+
+        2. The example above might be very limited if the use case requires sending many tests at once,
+           in this case, the second way might be better (log, metadata and attachments are optional):
+
+            $ squad-client submit \
+                  --group mygroup \
+                  --project myproject \
+                  --build mybuild
+                  --environment myenv
+                  --results results-file.json \
+                  --logs name-of-test-log-file.log \
+                  --metadata name-of-test-metadata-file.log \
+                  --attachments attachment1.log attachment2.png attachment3.xml
+
+        3. Finally, there's a third alternative which used TuxBuild's (https://gitlab.com/Linaro/tuxbuild)
+           format (log, metadata and attachments are optional):
+
+            $ squad-client submit
+                  --group mygroup \
+                  --project myproject \
+                  --results tuxbuild-results-file.json \
+                  --results-layout tuxbuild
+                  --logs name-of-test-log-file.log \
+                  --metadata name-of-test-metadata-file.log \
+                  --attachments attachment1.log attachment2.png attachment3.xml
+
+        Note that using `--results-layout tuxbuild` makes `--environment` and `--build` optional
+    """
     command = "submit"
     help_text = "submit results to SQUAD"
 
     def register(self, subparser):
         parser = super(SubmitCommand, self).register(subparser)
-        result_group = parser.add_mutually_exclusive_group()
-        result_group.add_argument(
-            "--results",
-            help="File with test results to submit. Max 5MB. JSON and YAML formats are supported",
-        )
-        result_group.add_argument(
-            "--result-name",
-            help="Single result name. Please use suite_name/test_name as value for this parameter"
+
+        # Group and project are always mandatory
+        parser.add_argument(
+            "--group", help="SQUAD group where results are stored", required=True
         )
         parser.add_argument(
-            "--result-value",
-            help="Single result output (pass/fail/skip)",
-            choices=["pass", "fail", "skip"],
+            "--project", help="SQUAD project where results are stored", required=True
         )
-        parser.add_argument(
-            "--results-layout",
-            help="Layout of the results file, if any",
-            choices=["tuxbuild"],
-        )
+
+        # metrics, metadata, logs and attachments are always optional
         parser.add_argument(
             "--metrics",
             help="File with metrics(benchmarsk) to submit. Max 5MB. JSON and YAML formats are supported",
@@ -49,20 +84,43 @@ class SubmitCommand(SquadClientCommand):
             help="Job attachments. Multiple files are allowed",
             default=[],
         )
-        parser.add_argument("--logs", help="Test log file path")
         parser.add_argument(
-            "--group", help="SQUAD group where results are stored", required=True
+            "--logs",
+            help="Test log file path"
+        )
+
+        # Results might be submitted using a result file one-by-one or using a file
+        result_group = parser.add_mutually_exclusive_group()
+
+        # Results file
+        result_group.add_argument(
+            "--results",
+            help="File with test results to submit. Max 5MB. JSON and YAML formats are supported",
+        )
+
+        # Individual results can use name, value, metrics file, metadata file and multiple attachment files
+        result_group.add_argument(
+            "--result-name",
+            help="Single result name. Please use suite_name/test_name as value for this parameter"
         )
         parser.add_argument(
-            "--project", help="SQUAD project where results are stored", required=True
+            "--result-value",
+            help="Single result output (pass/fail/skip)",
+            choices=["pass", "fail", "skip"],
         )
         parser.add_argument(
-            "--build", help="Build version where results are stored", required=True
+            "--results-layout",
+            help="Layout of the results file, if any",
+            choices=["tuxbuild"],
+        )
+
+        parser.add_argument(
+            "--build",
+            help="Build version where results are stored"
         )
         parser.add_argument(
             "--environment",
             help="Build environent where results are stored",
-            required=True,
         )
 
     def __check_file(self, file_path):
@@ -103,6 +161,8 @@ class SubmitCommand(SquadClientCommand):
         try:
             with open(path) as f:
                 tb = {}
+                # TODO: extra build version (git-describe) and environment (arch)
+                # and build results_dict with builds and environments according to the documentation above
                 builds = json.load(f)
 
                 for b in builds:
@@ -138,10 +198,20 @@ class SubmitCommand(SquadClientCommand):
         )
 
     def run(self, args):
+        """
+            results_dict = {
+                'buildA': {
+                    'envA': [{'suiteA/testA': 'pass'}, {'suiteA/testB': 'fail'}],
+                    'envB': [{'suiteA/testA': 'pass'}, {'suiteA/testB': 'fail'}]
+                },
+                'buildB': {...}
+            }
+        """
         results_dict = {}
         metrics_dict = {}
         metadata_dict = None
         logs_file = None
+
         if args.result_name:
             if not args.result_value:
                 logger.error("Test result value is required")
@@ -150,9 +220,22 @@ class SubmitCommand(SquadClientCommand):
 
         if args.results:
             if args.results_layout == 'tuxbuild':
+                if args.environment:
+                    logger.warning('Deprecation notice: --environment is being ignored when using --results-layout=tuxbuild. Future releases will cause it to break')
+                if args.build:
+                    logger.warning('Deprecation notice: --build is being ignored when using --results-layout=tuxbuild. Future releases will cause it to break')
+
                 results_dict = self._load_tuxbuild(args.results)
             else:
-                results_dict = self.__read_input_file(args.results)
+                if args.environment is None or args.build is None:
+                    logger.error('--environment and --build arguments are mandatory')
+                    return False
+
+                results_dict = {
+                    args.build: {
+                        args.environment: self.__read_input_file(args.results)
+                    }
+                }
 
             if results_dict is None:
                 return False
@@ -213,14 +296,18 @@ class SubmitCommand(SquadClientCommand):
                     logger.error("Incompatible metadata detected")
                     return False
 
-        submit_results(
-            group_project_slug="%s/%s" % (args.group, args.project),
-            build_version=args.build,
-            env_slug=args.environment,
-            tests=results_dict,
-            metrics=metrics_dict,
-            log=logs_file,
-            metadata=metadata_dict,
-        )
+        for build in results_dict.keys():
+            for environment in results_dict[build].keys():
+                results = results_dict[build][environment]
+
+                submit_results(
+                    group_project_slug="%s/%s" % (args.group, args.project),
+                    build_version=build,
+                    env_slug=environment,
+                    tests=results,
+                    metrics=metrics_dict,
+                    log=logs_file,
+                    metadata=metadata_dict,
+                )
 
         return True


### PR DESCRIPTION
This is a WIP for a request from @roxell when `--results-layout=tuxbuil` is given to `squad-client submit`.

The objective is to avoid having `--environment` and `--build` passed via cmdline, and extract those information from `build.json` generated by tuxbuild. Environment would be extracted from `arch` and build from `git-describe`.

I'm OK with that, but the only thing I'm stuck on is how to pass metrics, attachments and logs along tuxbuild results.

I initially suggested @jscook2345 to pass a flag to squad-client rather than making up a new command for this. But now I'm starting to think the best way should be a new command for this specifically. 

Thoughts? @roxell @mwasilew @jscook2345 ?