### PR TITLE
core: models: add tests endpoint to build

### DIFF
--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -383,6 +383,14 @@ class Build(SquadObject):
 
         return testruns
 
+    __tests__ = None
+
+    def tests(self, count=ALL, **filters):
+        if self.__tests__ is None:
+            endpoint = '%s%d/tests/' % (self.endpoint, self.id)
+            self.__tests__ = self.__fetch__(Test, filters, count, endpoint=endpoint)
+        return self.__tests__
+
     __metadata__ = None
     __status__ = None
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -38,10 +38,10 @@ metadata_my_xfailed_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test',
 metadata_my_skipped_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test', suite=suite.slug, name='my_skipped_test')
 
 testrun = build.test_runs.create(environment=environment)
-passed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_passed_test)
-failed_test = testrun.tests.create(suite=suite, result=False, metadata=metadata_my_failed_test)
-xfailed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_xfailed_test, has_known_issues=True)
-skipped_test = testrun.tests.create(suite=suite, result=None, metadata=metadata_my_skipped_test)
+passed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_passed_test, build=testrun.build, environment=testrun.environment)
+failed_test = testrun.tests.create(suite=suite, result=False, metadata=metadata_my_failed_test, build=testrun.build, environment=testrun.environment)
+xfailed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_xfailed_test, has_known_issues=True, build=testrun.build, environment=testrun.environment)
+skipped_test = testrun.tests.create(suite=suite, result=None, metadata=metadata_my_skipped_test, build=testrun.build, environment=testrun.environment)
 
 RecordTestRunStatus()(testrun)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -97,7 +97,7 @@ class SquadTest(unittest.TestCase):
 class BuildTest(unittest.TestCase):
 
     def setUp(self):
-        self.build = first(Squad().builds(count=1))
+        self.build = first(Squad().builds(version='my_build'))
 
     def test_basic(self):
         self.assertTrue(self.build is not None)
@@ -105,6 +105,18 @@ class BuildTest(unittest.TestCase):
     def test_build_metadata(self):
         metadata = self.build.metadata
         self.assertTrue(metadata.__id__ != '')
+
+    def test_build_tests(self):
+        tests = self.build.tests().values()
+        self.assertEqual(4, len(tests))
+
+    def test_build_tests_per_environment(self):
+        tests = self.build.tests(environment__slug='my_env').values()
+        self.assertEqual(4, len(tests))
+
+    def test_build_tests_per_environment_not_found(self):
+        tests = self.build.tests(environment__slug='mynonexistentenv').values()
+        self.assertEqual(0, len(tests))
 
 
 class TestRunTest(unittest.TestCase):


### PR DESCRIPTION
This will alow fetching tests directly from the build endpoint, making a way around testrun