### PR TITLE
commands: submit_tuxbuild: fix key in case of builds with dotted version

### DIFF
--- a/squad_client/commands/submit_tuxbuild.py
+++ b/squad_client/commands/submit_tuxbuild.py
@@ -108,14 +108,14 @@ class SubmitTuxbuildCommand(SquadClientCommand):
             toolchain = build["toolchain"]
             test = self._get_test_name(kconfig, toolchain)
 
-            multi_key = "%s.%s" % (description, arch)
+            multi_key = (description, arch)
             if multi_key not in data:
                 data[multi_key] = {}
 
             data[multi_key].update({test: status})
 
         for key, result in data.items():
-            description, arch = key.split(".", 1)
+            description, arch = key
             submit_results(
                 group_project_slug="%s/%s" % (args.group, args.project),
                 build_version=description,

--- a/tests/data/submit/tuxbuild/build.json
+++ b/tests/data/submit/tuxbuild/build.json
@@ -51,5 +51,31 @@
         "toolchain": "gcc-9",
         "tuxbuild_status": "complete",
         "warnings_count": 2
+    },
+    {
+        "build_key": "B3TECkH4_1X9yKoWOPIhed",
+        "build_status": "fail",
+        "client_token": "32b482ac-2cc1-4f68-bf73-cc9f780b72cf",
+        "download_url": "https://builds.tuxbuild.com/B3TECkH4_1X9yKoWOPIhew/",
+        "errors_count": 2,
+        "git_describe": "v4.4.4",
+        "git_repo": "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
+        "git_sha": "5302568121ba345f5c22528aefd72d775f25221e",
+        "git_short_log": "5302568121ba (\"Add linux-next specific files for 20201021\")",
+        "kconfig": [
+            "defconfig",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft.config",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft-crypto.config",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/distro-overrides.config",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/systemd.config",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/virtio.config",
+            "CONFIG_ARM64_MODULE_PLTS=y"
+        ],
+        "kernel_version": "5.9.0",
+        "status_message": "build failed due to compilation error(s)",
+        "target_arch": "arm64",
+        "toolchain": "gcc-9",
+        "tuxbuild_status": "complete",
+        "warnings_count": 2
     }
 ]

--- a/tests/test_submit_tuxbuild.py
+++ b/tests/test_submit_tuxbuild.py
@@ -51,10 +51,15 @@ class SubmitTuxbuildCommandTest(unittest.TestCase):
     def test_submit_tuxbuild_build(self):
         proc = self.submit_tuxbuild("tests/data/submit/tuxbuild/build.json")
         self.assertTrue(proc.ok, msg=proc.err)
-        self.assertTrue(proc.err.count("Submitting 1 tests") == 2)
+        self.assertTrue(proc.err.count("Submitting 1 tests") == 3)
 
         build = (
             self.squad.group("my_group").project("my_project").build("next-20201021")
+        )
+        self.assertIsNotNone(build)
+
+        build = (
+            self.squad.group("my_group").project("my_project").build("v4.4.4")
         )
         self.assertIsNotNone(build)
 


### PR DESCRIPTION
It'll prevent things like this from happening: https://qa-reports.linaro.org/lkft/linux-stable-rc-linux-4.14.y/build/v4/?failures_only=false&results_layout=envbox#!#test-results