### PR TITLE
squad_client: use module name for the logger name

### DIFF
--- a/squad_client/commands/create_or_update_project.py
+++ b/squad_client/commands/create_or_update_project.py
@@ -4,7 +4,7 @@ from squad_client.shortcuts import create_or_update_project
 from squad_client.core.command import SquadClientCommand
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class CreateOrUpdateProjectCommand(SquadClientCommand):

--- a/squad_client/commands/report.py
+++ b/squad_client/commands/report.py
@@ -9,7 +9,7 @@ from squad_client.core.command import SquadClientCommand
 from squad_client.report import ReportGenerator
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class ReportCommand(SquadClientCommand):

--- a/squad_client/commands/shell.py
+++ b/squad_client/commands/shell.py
@@ -6,7 +6,7 @@ import sys
 from squad_client.core.command import SquadClientCommand
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class ShellCommand(SquadClientCommand):

--- a/squad_client/commands/submit.py
+++ b/squad_client/commands/submit.py
@@ -6,7 +6,7 @@ from squad_client.shortcuts import submit_results
 from squad_client.core.command import SquadClientCommand
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class SubmitCommand(SquadClientCommand):

--- a/squad_client/commands/submit_tuxbuild.py
+++ b/squad_client/commands/submit_tuxbuild.py
@@ -5,7 +5,7 @@ import logging
 from squad_client.shortcuts import submit_results
 from squad_client.core.command import SquadClientCommand
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 tuxbuild_schema = {
     "type": "array",

--- a/squad_client/commands/test.py
+++ b/squad_client/commands/test.py
@@ -5,7 +5,7 @@ from squad_client.core.command import SquadClientCommand
 INCLUDE_TESTS_CMD = True
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 try:

--- a/squad_client/core/api.py
+++ b/squad_client/core/api.py
@@ -13,7 +13,7 @@ url_validator_regex = re.compile(
     r'(?:/?|[/?]\S+)$', re.IGNORECASE)
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 # ref: https://git.linaro.org/lava/lava-lab.git/tree/shared/lab-scripts/rerun_health_check.py#n13

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -10,7 +10,7 @@ from squad_client.utils import first, parse_test_name, parse_metric_name, to_jso
 from squad_client import settings
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 DEFAULT_COUNT = settings.DEFAULT_NUM_OF_OBJECTS
 ALL = -1

--- a/squad_client/manage.py
+++ b/squad_client/manage.py
@@ -12,7 +12,7 @@ from squad_client.core.command import SquadClientCommand
 from squad_client.commands import *  # noqa
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 formatter = logging.Formatter('[%(levelname)s] %(message)s')
 ch = logging.StreamHandler()

--- a/squad_client/report.py
+++ b/squad_client/report.py
@@ -12,7 +12,7 @@ from squad_client.core.models import SquadObject, Squad
 from squad_client.exceptions import InvalidReportOutput, InvalidReportTemplate
 
 
-logger = logging.getLogger('reporting')
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 


### PR DESCRIPTION
In general it is a good practice to use the module name for the logger
such that it can be controlled within the python logging configuration
without modifying other loggers.

Right now, without this change, you have to change the root logger
configuration, which could impact other libraries or scripts.

Signed-off-by: Justin Cook <justin.cook@linaro.org>