### PR TITLE
core: api: configure cache in SquadApi.configure()

### DIFF
--- a/squad_client/core/api.py
+++ b/squad_client/core/api.py
@@ -1,4 +1,5 @@
 import requests
+import requests_cache
 import urllib
 import re
 
@@ -49,7 +50,7 @@ class SquadApi:
     version = None
 
     @staticmethod
-    def configure(url, token=None):
+    def configure(url, token=None, cache=0):
         if url is None or url_validator_regex.match(url) is None:
             raise ApiException('Malformed url: "%s"' % url)
 
@@ -67,6 +68,10 @@ class SquadApi:
             SquadApi.version = squad_server_version.text
             if squad_server_version.text.split('.') < min_squad_version.split('.'):
                 logger.warning('You are running squad-client against and old (< %s) version of squad server, somethings might not work as expected!' % min_squad_version)
+
+        if cache > 0:
+            logger.debug('Caching results in "squad_client_cache.sqlite" for %d seconds' % cache)
+            requests_cache.install_cache('squad_client_cache', expire_after=cache)
 
     @staticmethod
     def get(endpoint, params={}):

--- a/squad_client/manage.py
+++ b/squad_client/manage.py
@@ -2,7 +2,6 @@
 
 import argparse
 import os
-import requests_cache
 import sys
 
 
@@ -39,7 +38,7 @@ def main():
             return -1
 
         try:
-            SquadApi.configure(squad_host, token=squad_token)
+            SquadApi.configure(squad_host, token=squad_token, cache=args.cache)
         except ApiException as e:
             logger.error('Failed to configure squad api: %s' % e)
             return -1
@@ -52,10 +51,6 @@ def main():
     if args.command is None:
         parser.print_help()
         return -1
-
-    if args.cache > 0:
-        logger.debug('Caching results in "squad_client_cache.sqlite" for %d seconds' % args.cache)
-        requests_cache.install_cache('squad_client_cache', expire_after=args.cache)
 
     rc = SquadClientCommand.process(args)
     return 1 if rc is False else 0 if rc is True else -1


### PR DESCRIPTION
This way libs that use squad-client can turn it on/off without having to use squad-client as a CLI