### PR TITLE
dockerfile: add bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV BUILD_DEPS="\
 "
 
 ENV RUNTIME_DEPS="\
+    bash \
     wkhtmltopdf \
     yaml \
 "


### PR DESCRIPTION
alpine does not include bash by default (only sh).

bash is required for our pipeline usage of squad-client, so this would
be nice to include.

Signed-off-by: Justin Cook <justin.cook@linaro.org>