### PR TITLE
Add submit TuxSuite command

### DIFF
--- a/squad_client/commands/submit_tuxsuite.py
+++ b/squad_client/commands/submit_tuxsuite.py
@@ -1,0 +1,121 @@
+import json
+import requests
+
+from squad_client import logging
+from squad_client.shortcuts import watchjob
+from squad_client.core.command import SquadClientCommand
+
+
+logger = logging.getLogger(__name__)
+
+
+class SubmitTuxSuiteCommand(SquadClientCommand):
+    command = "submit-tuxsuite"
+    help_text = "submit TuxSuite results to SQUAD"
+
+    def register(self, subparser):
+        parser = super(SubmitTuxSuiteCommand, self).register(subparser)
+        parser.add_argument(
+            "--group", help="SQUAD group where results are stored", required=True
+        )
+        parser.add_argument(
+            "--project", help="SQUAD project where results are stored", required=True
+        )
+        parser.add_argument(
+            "--build", help="SQUAD build where results are stored", required=False
+        )
+        parser.add_argument(
+            "--backend", help="SQUAD backend to be used to process results", required=True
+        )
+        parser.add_argument(
+            "--json", help="File with tuxsuite results to submit", required=True
+        )
+
+    def _load_results_file(self, path):
+        try:
+            with open(path) as f:
+                results = json.load(f)
+        except Exception as e:
+            logger.error("Failed to load json: %s", e)
+
+        # results file can be one of 3 types: build.json, test.json or plan.json
+        # the plan.json contains both tests and build results formatted as: {"builds": {}, "tests": {}}
+        # both test.json and build.json contains either tests or builds only, respectively, formatted as: [{}]
+        if type(results) == dict:
+            return results
+
+        # index results using uid
+        indexed = {r['uid']: r for r in results}
+
+        # now attempt to identify the results type
+        if results[0].get('build_name') is not None:
+            results = {'builds': indexed, 'tests': {}}
+        else:
+            results = {'tests': indexed, 'builds': {}}
+        return results
+
+    def _generate_job_id(self, result_type, result):
+        """
+            The job id for TuxSuite results is generated using 3 pieces of info:
+            1. If it's either "BUILD" or "TEST" result;
+            2. The TuxSuite project. Ex: "linaro/anders"
+            3. The ksuid of the object. Ex: "1yPYGaOEPNwr2pfqBgONY43zORp"
+
+            A couple examples for job_id are:
+            - BUILD:linaro@anders#1yPYGaOEPNwr2pCqBgONY43zORq
+            - TEST:arm@bob#1yPYGaOEPNwr2pCqBgONY43zORp
+
+            Then it's up to SQUAD's TuxSuite backend to parse the job_id
+            and fetch results properly.
+        """
+        _type = 'TEST' if result_type == 'tests' else 'BUILD'
+        project = result['project'].replace('/', '@')
+        uid = result['uid']
+        return f'{_type}:{project}#{uid}'
+
+    def run(self, args):
+        """
+            Submitting TuxSuite results to SQUAD basically consists of:
+            1. Parsing the TuxSuite results file
+            2. Triggering a watchjob on every build or test result that has result!=unknown in
+               TuxSuite results file
+            3. Once SQUAD receives the watchjob request, it'll be responsible for
+               retrieving important data out of TuxSuite api endpoints
+        """
+        results = self._load_results_file(args.json)
+        if results is None:
+            return False
+
+        # If build is not specified, then fetch the first build
+        # to get git-describe out of status.json
+        build = args.build
+        if build is None:
+            first_build = results['builds'][0]
+            try:
+                response = requests.get('%s/%s' % (first_build['download_url'], 'status.json'))
+                build = response.json()['git-describe']
+            except Exception as e:
+                logger.error("Failed to retrieve tuxsuite build: %s" % e)
+                return False
+
+        env_key = lambda result_type: 'device' if result_type == 'tests' else 'target_arch'  # noqa
+        for result_type in ['builds', 'tests']:
+            num_watching_jobs = 0
+            for result in results[result_type].values():
+                if result['result'] == 'unknown':
+                    continue
+
+                job_id = self._generate_job_id(result_type, result)
+
+                num_watching_jobs += 1
+                watchjob(
+                    group_project_slug='%s/%s' % (args.group, args.project),
+                    build_version=build,
+                    env_slug=result[env_key(result_type)],
+                    backend_name=args.backend,
+                    testjob_id=job_id,
+                )
+
+            logger.info(f"Triggered {num_watching_jobs} watch jobs for {result_type}")
+
+        return True

--- a/squad_client/core/api.py
+++ b/squad_client/core/api.py
@@ -123,6 +123,7 @@ class SquadApi:
             elif response.status_code == 403:
                 raise ApiException('%s %s is forbidden' % (method, endpoint))
             elif response.status_code == 500:
+                logger.error(response.text)
                 logger.error('You hit a bug in SQUAD, please report it at https://github.com/Linaro/squad/issues/new so we can get it fixed.')
 
             return response

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -306,6 +306,23 @@ class Squad(SquadObject):
             logger.error('Failed to submit job request: %s' % response.text)
         return response.ok
 
+    def watchjob(self, group=None, project=None, build=None, environment=None, backend=None, testjob_id=None):
+
+        path = '/api/watchjob/%s/%s/%s/%s' % (group.slug, project.slug, build.version, environment.slug)
+
+        data = {
+            'backend': backend.name,
+            'testjob_id': testjob_id,
+        }
+
+        logger.info('Watching job %s' % testjob_id)
+
+        response = SquadApi.post(path, data=data)
+        status_code = response.status_code
+        if status_code not in [200, 201, 500]:
+            logger.error('Failed to watch job: %s' % response.text)
+        return response.ok
+
 
 class Group(SquadObject):
 
@@ -511,6 +528,16 @@ class TestJob(SquadObject):
             environment=self.environment,
             backend=self.backend,
             definition=self.definition,)
+
+    def watch(self):
+        squad = Squad()
+        return squad.watchjob(
+            group=self.target.group,
+            project=self.target,
+            build=self.target_build,
+            environment=self.environment,
+            backend=self.backend,
+            testjob_id=self.job_id,)
 
 
 class MetricSuite:

--- a/squad_client/shortcuts.py
+++ b/squad_client/shortcuts.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from .core.models import ALL, Squad, Group, Project, Backend, Build, Environment, Test, Metric, MetricThreshold, TestRun, TestJob, SquadObjectException
+from .core.models import ALL, Squad, Group, Project, Build, Environment, Test, Metric, MetricThreshold, TestRun, TestJob, Backend, SquadObjectException
 from .utils import split_build_url, first, split_group_project_slug, getid
 
 
@@ -209,3 +209,29 @@ def create_or_update_project(group_slug=None, slug=None, name=None, description=
                 errors.append(str(e))
 
     return project, errors
+
+
+def watchjob(group_project_slug=None, build_version=None, env_slug=None, backend_name=None, testjob_id=None):
+    group_slug, project_slug = split_group_project_slug(group_project_slug)
+
+    group = Group()
+    project = Project()
+    build = Build()
+    testjob = TestJob()
+    environment = Environment()
+    backend = Backend()
+
+    group.slug = group_slug
+    project.group = group
+    project.slug = project_slug
+    backend.name = backend_name
+    environment.slug = env_slug
+    build.version = build_version
+
+    testjob.target_build = build
+    testjob.target = project
+    testjob.backend = backend
+    testjob.job_id = testjob_id
+    testjob.environment = environment
+
+    return testjob.watch()

--- a/squad_client/version.py
+++ b/squad_client/version.py
@@ -1,2 +1,2 @@
 __version__ = '0.26.5'
-__min_squad_version__ = '1.47'
+__min_squad_version__ = '1.51'

--- a/tests/commands/test_submit_tuxsuite.py
+++ b/tests/commands/test_submit_tuxsuite.py
@@ -1,0 +1,79 @@
+from unittest import TestCase
+import subprocess as sp
+
+
+from tests import settings
+from squad_client.core.api import SquadApi
+from squad_client.core.models import Squad
+
+
+class SubmitTuxSuiteTest(TestCase):
+    def setUp(self):
+        self.squad = Squad()
+
+        self.testing_server = 'http://localhost:%s' % settings.DEFAULT_SQUAD_PORT
+        self.testing_token = '193cd8bb41ab9217714515954e8724f651ef8601'
+        SquadApi.configure(self.testing_server, self.testing_token)
+
+    def manage_submit_tuxsuite(self, group=None, project=None, build=None, backend=None, json_file=None):
+
+        argv = ['./manage.py', '--squad-host', self.testing_server, '--squad-token', self.testing_token, 'submit-tuxsuite']
+        if group:
+            argv += ['--group', group]
+        if project:
+            argv += ['--project', project]
+        if build:
+            argv += ['--build', build]
+        if backend:
+            argv += ['--backend', backend]
+        if json_file:
+            argv += ['--json', json_file]
+
+        proc = sp.Popen(argv, stdout=sp.PIPE, stderr=sp.PIPE)
+        proc.ok = False
+
+        try:
+            out, err = proc.communicate()
+            proc.ok = (proc.returncode == 0)
+        except sp.TimeoutExpired:
+            self.logger.error('Running "%s" time out after %i seconds!' % ' '.join(argv))
+            proc.kill()
+            out, err = proc.communicate()
+
+        proc.out = out.decode('utf-8')
+        proc.err = err.decode('utf-8')
+        return proc
+
+    def test_empty(self):
+        proc = self.manage_submit_tuxsuite()
+        self.assertFalse(proc.ok)
+        self.assertIn('the following arguments are required: --group, --project', proc.err)
+
+    def test_basics(self):
+        base_args = {
+            'group': 'my_group',
+            'project': 'my_project',
+            'build': 'my_tuxsuite_build',
+            'backend': 'my_tuxsuite_backend',
+        }
+
+        results = [
+            'tests/data/sample_tuxsuite_builds.json',
+            'tests/data/sample_tuxsuite_tests.json',
+            'tests/data/sample_tuxsuite_tuxplan.json'
+        ]
+
+        for results_file in results:
+            args = dict(list(base_args.items()) + [('json_file', results_file)])
+            proc = self.manage_submit_tuxsuite(**args)
+            self.assertTrue(proc.ok)
+
+        job_ids = [
+            'BUILD:linaro@lkft#2843VDPeVhg4yaTkgTur0T3ykmq',  # from sample_tuxsuite_builds.json
+            'TEST:linaro@lkft#1yPYGuuaUxuH42KrjEiokDrGRSQ',   # from sample_tuxsuite_tests.json
+            'BUILD:linaro@lkft#1yPYDyGoF449fDc374OsaWJVVzl',  # both below from sample_tuxsuite_tuxplan.json
+            'TEST:linaro@lkft#1yPYDsKqAtxplNqXIg6shMtrDvj',
+        ]
+        for job_id in job_ids:
+            testjob = self.squad.testjobs(job_id=job_id)
+            self.assertIsNotNone(testjob)

--- a/tests/data/sample_tuxsuite_builds.json
+++ b/tests/data/sample_tuxsuite_builds.json
@@ -1,0 +1,175 @@
+[
+    {
+        "auto_retry": true,
+        "build_name": "clang-12-lkftconfig",
+        "build_status": "pass",
+        "client_token": "f4e6dcd5-d8e0-4da4-b3f9-0729923322c1",
+        "download_url": "https://builds.tuxbuild.com/2843VDPeVhg4yaTkgTur0T3ykmq/",
+        "duration": 1069,
+        "environment": {},
+        "errors_count": 0,
+        "finished_time": "2022-04-20T14:00:26.865387",
+        "git_describe": "v5.17.4",
+        "git_ref": null,
+        "git_repo": "https://gitlab.com/Linaro/lkft/mirrors/stable/linux-stable-rc",
+        "git_sha": "7ec6d8ae728e2f3b91a4cfac5e664ca32eb213da",
+        "git_short_log": "7ec6d8ae728e (\"Linux 5.17.4\")",
+        "image_sha": "",
+        "kconfig": [
+            "defconfig",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft.config",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft-crypto.config",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/distro-overrides.config",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/systemd.config",
+            "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/virtio.config",
+            "CONFIG_ARM64_MODULE_PLTS=y",
+            "CONFIG_SYN_COOKIES=y",
+            "CONFIG_SCHEDSTATS=y"
+        ],
+        "kernel_image": "",
+        "kernel_image_name": "Image.gz",
+        "kernel_patch_file": "",
+        "kernel_version": "5.17.4",
+        "make_variables": {
+            "LLVM": "1",
+            "LLVM_IAS": "1"
+        },
+        "modules": true,
+        "no_cache": false,
+        "plan": "2843VENTuwTvVRSWk9LGmZ8EvTt",
+        "project": "linaro/lkft",
+        "provisioning_time": "2022-04-20T13:40:51.503285",
+        "result": "pass",
+        "retry": 0,
+        "retry_message": "",
+        "running_time": "2022-04-20T13:42:37.604992",
+        "sccache_hits": 6995,
+        "sccache_misses": 902,
+        "state": "finished",
+        "status_message": "build completed",
+        "target_arch": "arm64",
+        "targets": [],
+        "toolchain": "clang-12",
+        "tuxbuild_status": "complete",
+        "tuxmake_metadata": {
+            "compiler": {
+                "name": "clang",
+                "version": "12.0.1",
+                "version_full": "Debian clang version 12.0.1-++20211027092659+fed41342a82f-1~exp1~20211027213207.7"
+            },
+            "results": {
+                "artifacts": {
+                    "config": [
+                        "config"
+                    ],
+                    "debugkernel": [
+                        "vmlinux.xz",
+                        "System.map"
+                    ],
+                    "default": [],
+                    "dtbs": [
+                        "dtbs.tar.xz"
+                    ],
+                    "dtbs-legacy": [
+                        "dtbs.tar.xz"
+                    ],
+                    "headers": [
+                        "headers.tar.xz"
+                    ],
+                    "kernel": [
+                        "Image.gz"
+                    ],
+                    "log": [
+                        "build.log",
+                        "build-debug.log"
+                    ],
+                    "modules": [
+                        "modules.tar.xz"
+                    ],
+                    "xipkernel": []
+                },
+                "duration": {
+                    "build": 790.3359227180481,
+                    "cleanup": 1.7626926898956299,
+                    "copy": 0.04466605186462402,
+                    "metadata": 2.023331642150879,
+                    "prepare": 224.84718894958496,
+                    "validate": 0.00028514862060546875
+                },
+                "errors": 0,
+                "status": "PASS",
+                "targets": {
+                    "config": {
+                        "duration": 14.94137454032898,
+                        "status": "PASS"
+                    },
+                    "debugkernel": {
+                        "duration": 13.838847875595093,
+                        "status": "PASS"
+                    },
+                    "default": {
+                        "duration": 696.2680366039276,
+                        "status": "PASS"
+                    },
+                    "dtbs": {
+                        "duration": 10.676923036575317,
+                        "status": "PASS"
+                    },
+                    "dtbs-legacy": {
+                        "duration": 0.6766235828399658,
+                        "status": "SKIP"
+                    },
+                    "headers": {
+                        "duration": 5.1988465785980225,
+                        "status": "PASS"
+                    },
+                    "kernel": {
+                        "duration": 9.11332106590271,
+                        "status": "PASS"
+                    },
+                    "modules": {
+                        "duration": 39.33427858352661,
+                        "status": "PASS"
+                    },
+                    "xipkernel": {
+                        "duration": 0.28751111030578613,
+                        "status": "SKIP"
+                    }
+                },
+                "warnings": 1
+            },
+            "runtime": {
+                "image_digest": "855116176053.dkr.ecr.us-east-1.amazonaws.com/tuxmake/arm64_clang-12@sha256:64ea8346024a2603ab964e5274f2b4617c7c8b82e30c26dee26a5e51dc5ce788",
+                "image_name": "855116176053.dkr.ecr.us-east-1.amazonaws.com/tuxmake/arm64_clang-12",
+                "version": "podman version 3.3.1"
+            },
+            "tools": {
+                "ar": "GNU ar (GNU Binutils for Debian) 2.35.2",
+                "as": "GNU assembler (GNU Binutils for Debian) 2.35.2",
+                "bc": "bc 1.07.1",
+                "bison": "bison (GNU Bison) 3.7.5",
+                "ccache": "ccache version 4.2",
+                "clang": "Debian clang version 12.0.1-++20211027092659+fed41342a82f-1~exp1~20211027213207.7",
+                "depmod": "kmod version 28",
+                "fdformat": "fdformat from util-linux 2.36.1",
+                "flex": "flex 2.6.4",
+                "gcc": "gcc (Debian 10.2.1-6) 10.2.1 20210110",
+                "ld": "GNU ld (GNU Binutils for Debian) 2.35.2",
+                "lld": "Debian LLD 12.0.1 (compatible with GNU linkers)",
+                "make": "GNU Make 4.3",
+                "openssl": "OpenSSL 1.1.1n  15 Mar 2022",
+                "pahole": "v1.22",
+                "ps": "ps from procps-ng 3.3.17",
+                "sccache": "sccache 0.2.9"
+            },
+            "tuxmake": {
+                "version": "1.0.1"
+            }
+        },
+        "uid": "2843VDPeVhg4yaTkgTur0T3ykmq",
+        "user": "lkft@linaro.org",
+        "user_agent": "tuxsuite/0.43.8",
+        "waited_by": [],
+        "warnings_count": 1
+    }
+]

--- a/tests/data/sample_tuxsuite_tests.json
+++ b/tests/data/sample_tuxsuite_tests.json
@@ -1,0 +1,36 @@
+[
+    {
+            "boot_args": null,
+            "device": "qemu-ppc64",
+            "finished_time": null,
+            "kernel": null,
+            "mcp_fw": null,
+            "mcp_romfw": null,
+            "modules": null,
+            "parameters": {},
+            "plan": "1yPYDsKqAtxplNqXIg6shMtrDvj",
+            "project": "linaro/lkft",
+            "provisioning_time": null,
+            "result": "unknown",
+            "results": {},
+            "rootfs": null,
+            "running_time": null,
+            "scp_fw": null,
+            "scp_romfw": null,
+            "state": "waiting",
+            "tests": [
+                "boot",
+                "ltp-fcntl-locktests",
+                "ltp-fs_bind",
+                "ltp-fs_perms_simple",
+                "ltp-fsx",
+                "ltp-nptl",
+                "ltp-smoke"
+            ],
+            "uefi": null,
+            "uid": "1yPYGuuaUxuH42KrjEiokDrGRSQ",
+            "user": "anders.roxell@linaro.org",
+            "user_agent": "tuxsuite/0.34.2",
+            "waiting_for": "1yPYFzmqqQ7WViC3cdPUSnZXg6L"
+    }
+]

--- a/tests/data/sample_tuxsuite_tuxplan.json
+++ b/tests/data/sample_tuxsuite_tuxplan.json
@@ -1,0 +1,81 @@
+{
+    "builds": {
+        "1yPYDyGoF449fDc374OsaWJVVzl": {
+            "build_name": "armv7-gcc-11",
+            "client_token": "a4ae4ef4-a363-4fa0-83c2-499828692482",
+            "download_url": "https://builds.tuxbuild.com/1yPYDyGoF449fDc374OsaWJVVzl/",
+            "environment": {},
+            "errors_count": 0,
+            "finished_time": null,
+            "git_ref": "master",
+            "git_repo": "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/",
+            "git_sha": "1f77990c4b7960a82d599567c586ceb8289f71ed",
+            "kconfig": [
+                "defconfig",
+                "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft.config",
+                "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft-crypto.config",
+                "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/distro-overrides.config",
+                "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/systemd.config",
+                "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/virtio.config",
+                "CONFIG_ARM_TI_CPUFREQ=y",
+                "CONFIG_SERIAL_8250_OMAP=y",
+                "CONFIG_POSIX_MQUEUE=y",
+                "CONFIG_OF=y",
+                "CONFIG_SYN_COOKIES=y"
+            ],
+            "kernel_image": "",
+            "kernel_patch_file": "",
+            "make_variables": {},
+            "plan": "1yPYDsKqAtxplNqXIg6shMtrDvj",
+            "project": "linaro/lkft",
+            "provisioning_time": "2021-09-20T16:16:14.950674",
+            "result": "unknown",
+            "running_time": null,
+            "state": "provisioning",
+            "target_arch": "arm",
+            "targets": [],
+            "toolchain": "gcc-11",
+            "uid": "1yPYDyGoF449fDc374OsaWJVVzl",
+            "user": "anders.roxell@linaro.org",
+            "user_agent": "tuxsuite/0.34.2",
+            "waited_by": [],
+            "warnings_count": 0
+        }
+    },
+    "tests": {
+        "1yPYGaOEPNwr2pCqBgONY43zORp": {
+            "boot_args": null,
+            "device": "qemu-i386",
+            "finished_time": null,
+            "kernel": null,
+            "mcp_fw": null,
+            "mcp_romfw": null,
+            "modules": null,
+            "parameters": {},
+            "plan": "1yPYDsKqAtxplNqXIg6shMtrDvj",
+            "project": "linaro/lkft",
+            "provisioning_time": null,
+            "result": "unknown",
+            "results": {},
+            "rootfs": null,
+            "running_time": null,
+            "scp_fw": null,
+            "scp_romfw": null,
+            "state": "waiting",
+            "tests": [
+                "boot",
+                "ltp-fcntl-locktests",
+                "ltp-fs_bind",
+                "ltp-fs_perms_simple",
+                "ltp-fsx",
+                "ltp-nptl",
+                "ltp-smoke"
+            ],
+            "uefi": null,
+            "uid": "1yPYGaOEPNwr2pCqBgONY43zORp",
+            "user": "anders.roxell@linaro.org",
+            "user_agent": "tuxsuite/0.34.2",
+            "waiting_for": "1yPYFArSa1GUmMmrpwZq6KyU9T0"
+        }
+    }
+}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -50,6 +50,8 @@ RecordTestRunStatus()(testrun)
 testrun_no_metadata = build.test_runs.create(environment=environment)
 RecordTestRunStatus()(testrun_no_metadata)
 
+mci.Backend.objects.create(name='my_tuxsuite_backend', implementation_type='tuxsuite')
+
 backend = mci.Backend.objects.create(name='my_backend', implementation_type='lava')
 testjob = testrun.test_jobs.create(backend=backend, target=project, target_build=build)
 

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -12,6 +12,7 @@ from squad_client.shortcuts import (
     submit_results,
     submit_job,
     create_or_update_project,
+    watchjob,
 )
 
 
@@ -106,6 +107,35 @@ class SubmitJobShortcutTest(TestCase):
 
         for testjob in results.values():
             if testjob.environment == "my_submitted_env":
+                return
+
+        self.assertTrue(False)
+
+
+class WatchjobShortcutTest(TestCase):
+    def setUp(self):
+        self.squad = Squad()
+        SquadApi.configure(
+            url="http://localhost:%s" % settings.DEFAULT_SQUAD_PORT,
+            token="193cd8bb41ab9217714515954e8724f651ef8601",
+        )
+
+    def test_basic(self):
+        testjob_id = "watched-job-id"
+        success = watchjob(
+            group_project_slug="my_group/my_project",
+            build_version="my_build",
+            env_slug="my_env",
+            backend_name="my_backend",
+            testjob_id=testjob_id,
+        )
+
+        self.assertTrue(success)
+        results = self.squad.testjobs()
+        self.assertTrue(len(results) > 0)
+
+        for testjob in results.values():
+            if testjob.job_id == testjob_id:
                 return
 
         self.assertTrue(False)


### PR DESCRIPTION
This subcommand adds support for integrating TuxSuite and SQUAD. It should be used as:

```bash
$ squad-client submit-tuxsuite \
       --group lkft \
       --project linux-stable-rc-linux-5.12.y \
       --build v5.12.19 \
       --backend tuxsuite.com \
       --json results-from-tuxsuite-cli.json
```

The outcome of this command is subsequent calls to SQUAD's `/api/watchjob` endpoint, triggering the TuxSuite backend, fetching both build and results from Tux.