### PR TITLE
submit_tuxbuild: set schema version

### DIFF
--- a/squad_client/commands/submit_tuxbuild.py
+++ b/squad_client/commands/submit_tuxbuild.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 tuxbuild_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "array",
     "minItems": 1,
     "items": [{


### PR DESCRIPTION
Since we do not pin the version of jsonschema, an upstream change has
caused a problem with the pipeline.

jsonschema recently changed their default schema version to something
newer that is not compatiable with what we have defined in squad-client.

This sets the schema version to what it should be so that we can
investigate changing to the newer schema at a later date.

Signed-off-by: Justin Cook <justin.cook@linaro.org>