### PR TITLE
Enable metric threshold

### DIFF
--- a/squad_client/commands/create_or_update_project.py
+++ b/squad_client/commands/create_or_update_project.py
@@ -96,6 +96,11 @@ class CreateOrUpdateProjectCommand(SquadClientCommand):
             default=False,
             help="Return with exit code only, do not print errors whatsoever",
         )
+        parser.add_argument(
+            "--thresholds",
+            nargs="*",
+            help='Metric thresholds of the project. Exaple "build/*-warnings"',
+        )
 
     def resolve_boolean_flag(self, flag, no_flag):
         if flag:
@@ -110,6 +115,7 @@ class CreateOrUpdateProjectCommand(SquadClientCommand):
         moderate_notifications = self.resolve_boolean_flag(args.moderate_notifications, args.no_moderate_notifications)
         plugins = args.plugins.split(',') if args.plugins else None
         important_metadata_keys = args.important_metadata_keys.split(',') if args.important_metadata_keys else None
+        thresholds = args.thresholds
 
         project, errors = create_or_update_project(
             group_slug=args.group,
@@ -127,6 +133,7 @@ class CreateOrUpdateProjectCommand(SquadClientCommand):
             important_metadata_keys=important_metadata_keys,
             wait_before_notification_timeout=args.wait_before_notification_timeout,
             overwrite=(not args.no_overwrite),
+            thresholds=thresholds,
         )
 
         if project is None:
@@ -137,4 +144,7 @@ class CreateOrUpdateProjectCommand(SquadClientCommand):
         else:
             if not args.silent:
                 print('Project saved: %s' % project.url)
+                if len(errors):
+                    print('But some errors were found: %s' % errors, file=sys.stderr)
+                    return False
             return True

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -355,6 +355,10 @@ class Project(SquadObject):
         objects = self.suites(count=1, **filters)
         return first(objects)
 
+    def thresholds(self, count=DEFAULT_COUNT, **filters):
+        filters.update({'project': self.id})
+        return self.__fetch__(MetricThreshold, filters, count)
+
     def __repr__(self):
         return self.slug
 
@@ -661,7 +665,7 @@ class Annotation(SquadObject):
 class MetricThreshold(SquadObject):
 
     endpoint = '/api/metricthresholds/'
-    attrs = ['url', 'id', 'name', 'value', 'is_higher_better', 'environment']
+    attrs = ['url', 'id', 'name', 'value', 'is_higher_better', 'environment', 'project']
 
 
 class Report(SquadObject):

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -412,6 +412,16 @@ class Build(SquadObject):
             self.__tests__[filters_str] = self.__fetch__(Test, filters, count, endpoint=endpoint)
         return self.__tests__[filters_str]
 
+    __metrics__ = {}
+
+    def metrics(self, count=ALL, **filters):
+        filters['count'] = count
+        filters_str = str(OrderedDict(filters))
+        if self.__metrics__.get(filters_str) is None:
+            endpoint = '%s%d/metrics/' % (self.endpoint, self.id)
+            self.__metrics__[filters_str] = self.__fetch__(Metric, filters, count, endpoint=endpoint)
+        return self.__metrics__[filters_str]
+
     __metadata__ = None
     __status__ = None
 
@@ -481,7 +491,7 @@ class MetricSuite:
 
 class Metric(SquadObject):
     endpoint = '/api/metrics/'
-    attrs = ['url', 'id', 'name', 'short_name', 'measurement_list', 'result', 'unit', 'is_outlier', 'test_run', 'suite', 'metadata']
+    attrs = ['url', 'id', 'name', 'short_name', 'measurement_list', 'result', 'unit', 'is_outlier', 'test_run', 'suite', 'metadata', 'build', 'environment']
 
 
 class TestRunStatus(SquadObject):

--- a/squad_client/shortcuts.py
+++ b/squad_client/shortcuts.py
@@ -34,13 +34,11 @@ def retrieve_build_results(build_url):
         suite = suites[getid(test.suite)]
         results[env]['tests'][suite][test.short_name] = test.status
 
-    metrics = squad.metrics(test_run__build_id=build.id, fields='id,short_name,result,suite,test_run').values()
-    testruns = build.testruns(fields='id,environment')
+    metrics = build.metrics(fields='id,short_name,result,suite,environment').values()
     for metric in metrics:
-        testrun = testruns[getid(metric.test_run)]
-        env = environments[getid(testrun.environment)]
+        env = environments[getid(metric.environment)]
         suite = suites[getid(metric.suite)]
-        results[env]['metrics'][suite][metric.short_name] = metric.results
+        results[env]['metrics'][suite][metric.short_name] = metric.result
 
     return results
 

--- a/squad_client/shortcuts.py
+++ b/squad_client/shortcuts.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from .core.models import ALL, Squad, Group, Project, Backend, Build, Environment, Test, Metric, TestRun, TestJob, SquadObjectException
+from .core.models import ALL, Squad, Group, Project, Backend, Build, Environment, Test, Metric, MetricThreshold, TestRun, TestJob, SquadObjectException
 from .utils import split_build_url, first, split_group_project_slug, getid
 
 
@@ -118,7 +118,7 @@ def create_or_update_project(group_slug=None, slug=None, name=None, description=
                              is_public=None, html_mail=None, moderate_notifications=None, is_archived=None,
                              email_template=None, plugins=None, important_metadata_keys=None,
                              wait_before_notification_timeout=None, notification_timeout=None,
-                             data_retention=None, overwrite=False):
+                             data_retention=None, overwrite=False, thresholds=None):
     errors = []
     group = None
     project = None
@@ -178,4 +178,25 @@ def create_or_update_project(group_slug=None, slug=None, name=None, description=
 
     if len(errors):
         return None, errors
-    return project, []
+
+    # For now, this function only support project-wide, null-valued, lower-is-better metric thresholds
+    if thresholds:
+        project_thresholds = project.thresholds().values()
+        existing_thresholds = [t.name for t in project_thresholds if [t.environment, t.value, t.is_higher_better] == [None, None, False]]
+        for threshold in thresholds:
+            if threshold in existing_thresholds:
+                print('Threshold "%s" already exists, skip adding it' % threshold)
+                continue
+
+            # Create a metric threshold
+            new_threshold = MetricThreshold()
+            new_threshold.name = threshold
+            new_threshold.project = project
+
+            try:
+                new_threshold.save()
+                print('MetricThreshold saved: %s' % new_threshold.url)
+            except SquadObjectException as e:
+                errors.append(str(e))
+
+    return project, errors

--- a/squad_client/version.py
+++ b/squad_client/version.py
@@ -1,2 +1,2 @@
 __version__ = '0.20'
-__min_squad_version__ = '1.33'
+__min_squad_version__ = '1.43'

--- a/squad_client/version.py
+++ b/squad_client/version.py
@@ -1,2 +1,2 @@
 __version__ = '0.20'
-__min_squad_version__ = '1.43'
+__min_squad_version__ = '1.44'

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -50,5 +50,5 @@ testjob = testrun.test_jobs.create(backend=backend, target=project, target_build
 
 emailtemplate = m.EmailTemplate.objects.create(name='my_emailtemplate')
 suitemetadata = m.SuiteMetadata.objects.create(name='my_suitemetadata')
-metricthreshold = m.MetricThreshold.objects.create(environment=environment, value=42)
+metricthreshold = project.thresholds.create(environment=environment, value=42)
 report = build.delayed_reports.create()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -52,5 +52,5 @@ testjob = testrun.test_jobs.create(backend=backend, target=project, target_build
 
 emailtemplate = m.EmailTemplate.objects.create(name='my_emailtemplate')
 suitemetadata = m.SuiteMetadata.objects.create(name='my_suitemetadata')
-metricthreshold = project.thresholds.create(environment=environment, value=42)
+metricthreshold = project.thresholds.create(environment=environment, value=42, name='my-threshold')
 report = build.delayed_reports.create()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -36,12 +36,14 @@ metadata_my_passed_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test', 
 metadata_my_failed_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test', suite=suite.slug, name='my_failed_test')
 metadata_my_xfailed_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test', suite=suite.slug, name='my_xfailed_test')
 metadata_my_skipped_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test', suite=suite.slug, name='my_skipped_test')
+metadata_my_metric, _ = m.SuiteMetadata.objects.get_or_create(kind='metric', suite=suite.slug, name='my_metric')
 
 testrun = build.test_runs.create(environment=environment)
 passed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_passed_test, build=testrun.build, environment=testrun.environment)
 failed_test = testrun.tests.create(suite=suite, result=False, metadata=metadata_my_failed_test, build=testrun.build, environment=testrun.environment)
 xfailed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_xfailed_test, has_known_issues=True, build=testrun.build, environment=testrun.environment)
 skipped_test = testrun.tests.create(suite=suite, result=None, metadata=metadata_my_skipped_test, build=testrun.build, environment=testrun.environment)
+my_metric = testrun.metrics.create(suite=suite, result=1, metadata=metadata_my_metric, build=testrun.build, environment=testrun.environment)
 
 RecordTestRunStatus()(testrun)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -125,6 +125,25 @@ class BuildTest(unittest.TestCase):
         tests = self.build.tests(environment__slug='mynonexistentenv').values()
         self.assertEqual(0, len(tests))
 
+    def test_build_metrics(self):
+        tests = self.build.metrics().values()
+        self.assertEqual(1, len(tests))
+
+    def test_build_metrics_per_environment(self):
+        tests = self.build.metrics(environment__slug='my_env').values()
+        self.assertEqual(1, len(tests))
+
+    def test_build_metrics_per_environment_not_found(self):
+        tests = self.build.metrics(environment__slug='mynonexistentenv').values()
+        self.assertEqual(0, len(tests))
+
+    def test_build_metrics_change_cache_on_different_filters(self):
+        tests = self.build.metrics(environment__slug='my_env').values()
+        self.assertEqual(1, len(tests))
+
+        tests = self.build.metrics(environment__slug='mynonexistentenv').values()
+        self.assertEqual(0, len(tests))
+
 
 class TestRunTest(unittest.TestCase):
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -184,6 +184,12 @@ class ProjectTest(unittest.TestCase):
         suite = self.project.suite('my_suite')
         self.assertEqual(suite.slug, 'my_suite')
 
+    def test_project_thresholds(self):
+        thresholds = self.project.thresholds()
+        self.assertEqual(1, len(thresholds))
+        threshold = first(thresholds)
+        self.assertEqual(threshold.name, 'my-threshold')
+
     def test_compare_builds_from_same_project(self):
         comparison = self.project.compare_builds(self.build2.id, self.build.id)
         self.assertEqual('Cannot report regressions/fixes on non-finished builds', comparison[0])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -186,7 +186,7 @@ class ProjectTest(unittest.TestCase):
 
     def test_compare_builds_from_same_project(self):
         comparison = self.project.compare_builds(self.build2.id, self.build.id)
-        self.assertEqual('Cannot report regressions/fixes on a non-finished builds', comparison[0])
+        self.assertEqual('Cannot report regressions/fixes on non-finished builds', comparison[0])
 
     def test_compare_builds_from_same_project_force(self):
         comparison = self.project.compare_builds(self.build2.id, self.build.id, force=True)


### PR DESCRIPTION
This PR adds a new arg in `create-or-update-project` called `--thresholds` that makes sure required thresholds are in place.

The PR also fixes tests regarding the latest changes in SQUAD's MetricThreshold object.