### PR TITLE
test: install the python dependencies consistently

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          python -m pip install -r requirements-dev.txt
       - name: Run tests using unittest
         run: "./manage.py --squad-host http://localhost:9000 test -v"
 


### PR DESCRIPTION
To avoid installing python dependencies into different locations, try to
install them consistently by calling pip the same way across all the
action runs.

Signed-off-by: Justin Cook <justin.cook@linaro.org>