### PR TITLE
dockerfile: remove wkhtmltopdf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV BUILD_DEPS="\
 
 ENV RUNTIME_DEPS="\
     bash \
-    wkhtmltopdf \
     yaml \
 "
 


### PR DESCRIPTION
This was removed in the latest alpine release, so we are removing it
from the container for now.

https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.15.0#Significant_removals

Fixes #134

Signed-off-by: Justin Cook <justin.cook@linaro.org>