### PR TITLE
submit_tuxbuild: add config file url to the metadata

### DIFF
--- a/squad_client/commands/submit_tuxbuild.py
+++ b/squad_client/commands/submit_tuxbuild.py
@@ -54,6 +54,7 @@ tuxbuild_schema = {
 }
 
 ALLOWED_METADATA = [
+    "config",
     "download_url",
     "git_branch",
     "git_commit",
@@ -101,6 +102,9 @@ class SubmitTuxbuildCommand(SquadClientCommand):
 
         # We expect `make_kernelversion`, but tuxmake calls it `kernel_version`
         metadata.update({"make_kernelversion": metadata.get("kernel_version")})
+
+        # add config file to the metadata
+        metadata["config"] = f"{metadata.get('download_url')}/config"
 
         return metadata
 


### PR DESCRIPTION
Add a config field that points to tuxsuite's generated config artifact.
Shouldn't be needed to store the 'config' file since the tuxsuite url
are stored for 90 days, which should be enough time to report a
regression.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>