### PR TITLE
all: fetch the content of the metadata file

### DIFF
--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -542,6 +542,14 @@ class TestRun(SquadObject):
             self.__metrics__ = self.__fetch__(Metric, filters, count)
         return self.__metrics__
 
+    def metadata_file_content(self):
+        response = SquadApi.get(self.metadata_file)
+
+        if response.text == "None":
+            return None
+
+        return response.json()
+
     test_suites = []
     metric_suites = []
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -38,7 +38,7 @@ metadata_my_xfailed_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test',
 metadata_my_skipped_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test', suite=suite.slug, name='my_skipped_test')
 metadata_my_metric, _ = m.SuiteMetadata.objects.get_or_create(kind='metric', suite=suite.slug, name='my_metric')
 
-testrun = build.test_runs.create(environment=environment)
+testrun = build.test_runs.create(environment=environment, metadata_file='{"foo": "bar"}')
 passed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_passed_test, build=testrun.build, environment=testrun.environment)
 failed_test = testrun.tests.create(suite=suite, result=False, metadata=metadata_my_failed_test, build=testrun.build, environment=testrun.environment)
 xfailed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_xfailed_test, has_known_issues=True, build=testrun.build, environment=testrun.environment)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -157,6 +157,10 @@ class TestRunTest(unittest.TestCase):
         status = self.testrun.summary()
         self.assertEqual(1, status.tests_fail)
 
+    def test_testrun_metadata_file(self):
+        self.assertTrue(self.testrun.metadata_file is not None)
+        self.assertEqual(self.testrun.metadata_file_content(), {"foo": "bar"})
+
 
 class ProjectTest(unittest.TestCase):
 


### PR DESCRIPTION
This allows the user to rely on the squad-client library to fetch the
content of the metadata file instead of having to create their own fetch
request.

Signed-off-by: Justin Cook <justin.cook@linaro.org>