### PR TITLE
all: fetch testrun metadata from squad

### DIFF
--- a/squad_client/commands/submit.py
+++ b/squad_client/commands/submit.py
@@ -93,7 +93,7 @@ class SubmitCommand(SquadClientCommand):
     def run(self, args):
         results_dict = {}
         metrics_dict = {}
-        metadata_dict = None
+        metadata_dict = {}
         logs_file = None
         if args.result_name:
             if not args.result_value:

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -563,8 +563,13 @@ class TestRun(SquadObject):
     def metadata(self):
         if self.__metadata__ is None:
             response = SquadApi.get(self.metadata_file)
-            objects = self.__fill__(TestRunMetadata, [response.json()])
-            self.__metadata__ = first(objects)
+
+            if response.text == "None":
+                self.__metadata__ = None
+            else:
+                objects = self.__fill__(TestRunMetadata, [response.json()])
+                self.__metadata__ = first(objects)
+
         return self.__metadata__
 
     @metadata.setter

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from itertools import groupby
 from collections import OrderedDict
@@ -18,6 +19,17 @@ ALL = -1
 
 class SquadObjectException(Exception):
     pass
+
+
+class SquadObjectJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, uuid.UUID):
+            return str(o)
+        elif isinstance(o, TestRunMetadata):
+            d = {k: v for k, v in o.__dict__.items() if k != "id"}
+            return d
+        else:
+            return json.JSONEncoder.default(self, o)
 
 
 class SquadObject:
@@ -263,7 +275,7 @@ class Squad(SquadObject):
             num_metrics = len(metrics_dict)
             data['metrics'] = to_json(metrics_dict)
         if metadata:
-            data['metadata'] = to_json(metadata)
+            data['metadata'] = json.dumps(metadata, cls=SquadObjectJSONEncoder)
         if log:
             data['log'] = log
 
@@ -504,6 +516,10 @@ class TestRunStatus(SquadObject):
              'suite', 'suite_version']
 
 
+class TestRunMetadata(SquadObject):
+    pass
+
+
 class TestRun(SquadObject):
 
     endpoint = '/api/testruns/'
@@ -512,7 +528,6 @@ class TestRun(SquadObject):
              'job_id', 'job_status', 'job_url', 'resubmit_url',
              'data_processed', 'status_recorded', 'build',
              'environment']
-    metadata = None
     attachments = None
     log = None
 
@@ -541,6 +556,21 @@ class TestRun(SquadObject):
             filters.update({'test_run': self.id})
             self.__metrics__ = self.__fetch__(Metric, filters, count)
         return self.__metrics__
+
+    __metadata__ = None
+
+    @property
+    def metadata(self):
+        if self.__metadata__ is None:
+            response = SquadApi.get(self.metadata_file)
+            objects = self.__fill__(TestRunMetadata, [response.json()])
+            self.__metadata__ = first(objects)
+        return self.__metadata__
+
+    @metadata.setter
+    def metadata(self, new_metadata):
+        objects = self.__fill__(TestRunMetadata, [new_metadata])
+        self.__metadata__ = first(objects)
 
     test_suites = []
     metric_suites = []

--- a/squad_client/shortcuts.py
+++ b/squad_client/shortcuts.py
@@ -43,7 +43,7 @@ def retrieve_build_results(build_url):
     return results
 
 
-def submit_results(group_project_slug=None, build_version=None, env_slug=None, tests={}, metrics={}, log=None, metadata=None, attachments=None):
+def submit_results(group_project_slug=None, build_version=None, env_slug=None, tests={}, metrics={}, log=None, metadata={}, attachments=None):
     group_slug, project_slug = split_group_project_slug(group_project_slug)
 
     # TODO: validate input

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -38,7 +38,7 @@ metadata_my_xfailed_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test',
 metadata_my_skipped_test, _ = m.SuiteMetadata.objects.get_or_create(kind='test', suite=suite.slug, name='my_skipped_test')
 metadata_my_metric, _ = m.SuiteMetadata.objects.get_or_create(kind='metric', suite=suite.slug, name='my_metric')
 
-testrun = build.test_runs.create(environment=environment)
+testrun = build.test_runs.create(environment=environment, metadata_file='{"foo": "bar"}')
 passed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_passed_test, build=testrun.build, environment=testrun.environment)
 failed_test = testrun.tests.create(suite=suite, result=False, metadata=metadata_my_failed_test, build=testrun.build, environment=testrun.environment)
 xfailed_test = testrun.tests.create(suite=suite, result=True, metadata=metadata_my_xfailed_test, has_known_issues=True, build=testrun.build, environment=testrun.environment)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -47,6 +47,9 @@ my_metric = testrun.metrics.create(suite=suite, result=1, metadata=metadata_my_m
 
 RecordTestRunStatus()(testrun)
 
+testrun_no_metadata = build.test_runs.create(environment=environment)
+RecordTestRunStatus()(testrun_no_metadata)
+
 backend = mci.Backend.objects.create(name='my_backend', implementation_type='lava')
 testjob = testrun.test_jobs.create(backend=backend, target=project, target_build=build)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -148,7 +148,9 @@ class BuildTest(unittest.TestCase):
 class TestRunTest(unittest.TestCase):
 
     def setUp(self):
-        self.testrun = first(Squad().testruns(count=1))
+        self.testruns = Squad().testruns(count=2)
+        self.testrun = self.testruns[1]
+        self.testrun_no_metadata = self.testruns[2]
 
     def test_basic(self):
         self.assertTrue(self.testrun is not None)
@@ -157,6 +159,9 @@ class TestRunTest(unittest.TestCase):
         self.assertTrue(self.testrun.metadata_file is not None)
         self.assertTrue(self.testrun.metadata is not None)
         self.assertEqual(self.testrun.metadata.foo, "bar")
+
+        self.assertTrue(self.testrun_no_metadata.metadata_file is not None)
+        self.assertTrue(self.testrun_no_metadata.metadata is None)
 
     def test_testrun_status(self):
         status = self.testrun.summary()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -153,6 +153,11 @@ class TestRunTest(unittest.TestCase):
     def test_basic(self):
         self.assertTrue(self.testrun is not None)
 
+    def test_testrun_metadata(self):
+        self.assertTrue(self.testrun.metadata_file is not None)
+        self.assertTrue(self.testrun.metadata is not None)
+        self.assertEqual(self.testrun.metadata.foo, "bar")
+
     def test_testrun_status(self):
         status = self.testrun.summary()
         self.assertEqual(1, status.tests_fail)


### PR DESCRIPTION
Treat the testrun metadata like a squadobject, and use the built-in
features to send and recieve it.

Originally this was treated like a dictionary, and so there are some
changes related to that.

Because the testrun metadata does not really use an id, we remove the
uuid when we encode it to json.

Signed-off-by: Justin Cook <justin.cook@linaro.org>