### PR TITLE
core: models: add field for forcing builds finishing on timeout

### DIFF
--- a/squad_client/commands/create_or_update_project.py
+++ b/squad_client/commands/create_or_update_project.py
@@ -68,6 +68,11 @@ class CreateOrUpdateProjectCommand(SquadClientCommand):
             type=int,
         )
         parser.add_argument(
+            "--force-finishing-builds-on-timeout",
+            help='Forces builds to finish when "Notification timeout" is reached but it does not kill any pending job',
+            choices=["True", "true", "False", "false"],
+        )
+        parser.add_argument(
             "--notification-timeout",
             help="Force sending build notifications after this many seconds",
             type=int,
@@ -117,6 +122,10 @@ class CreateOrUpdateProjectCommand(SquadClientCommand):
         important_metadata_keys = args.important_metadata_keys.split(',') if args.important_metadata_keys else None
         thresholds = args.thresholds
 
+        force_finishing_builds_on_timeout = None
+        if args.force_finishing_builds_on_timeout:
+            force_finishing_builds_on_timeout = args.force_finishing_builds_on_timeout.endswith("rue")
+
         project, errors = create_or_update_project(
             group_slug=args.group,
             slug=args.slug,
@@ -132,6 +141,7 @@ class CreateOrUpdateProjectCommand(SquadClientCommand):
             moderate_notifications=moderate_notifications,
             important_metadata_keys=important_metadata_keys,
             wait_before_notification_timeout=args.wait_before_notification_timeout,
+            force_finishing_builds_on_timeout=force_finishing_builds_on_timeout,
             overwrite=(not args.no_overwrite),
             thresholds=thresholds,
         )

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -338,7 +338,7 @@ class Project(SquadObject):
     attrs = ['id', 'custom_email_template', 'data_retention_days', 'description',
              'enabled_plugins_list', 'full_name', 'group', 'html_mail', 'important_metadata_keys',
              'is_archived', 'is_public', 'moderate_notifications', 'name', 'notification_timeout',
-             'slug', 'url', 'wait_before_notification']
+             'slug', 'url', 'wait_before_notification', 'force_finishing_builds_on_timeout']
 
     def builds(self, count=DEFAULT_COUNT, **filters):
         filters.update({'project': self.id})

--- a/squad_client/shortcuts.py
+++ b/squad_client/shortcuts.py
@@ -118,7 +118,8 @@ def create_or_update_project(group_slug=None, slug=None, name=None, description=
                              is_public=None, html_mail=None, moderate_notifications=None, is_archived=None,
                              email_template=None, plugins=None, important_metadata_keys=None,
                              wait_before_notification_timeout=None, notification_timeout=None,
-                             data_retention=None, overwrite=False, thresholds=None):
+                             data_retention=None, overwrite=False, thresholds=None,
+                             force_finishing_builds_on_timeout=None):
     errors = []
     group = None
     project = None
@@ -170,6 +171,8 @@ def create_or_update_project(group_slug=None, slug=None, name=None, description=
         project.important_metadata_keys = '\n'.join(important_metadata_keys) if type(important_metadata_keys) == list else important_metadata_keys
     if wait_before_notification_timeout is not None:
         project.wait_before_notification = wait_before_notification_timeout
+    if force_finishing_builds_on_timeout is not None:
+        project.force_finishing_builds_on_timeout = force_finishing_builds_on_timeout
 
     try:
         project.save()

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -167,6 +167,7 @@ class CreateOrUpdateShortcutTest(TestCase):
             wait_before_notification_timeout=60,
             notification_timeout=120,
             data_retention=1,
+            force_finishing_builds_on_timeout=True,
         )
 
         self.assertIsNotNone(project)


### PR DESCRIPTION
Add the flag to force finishing builds on timeout to squad-client. Also add that to the `create-or-update-project` command