### PR TITLE
commands: submit_tuxbuild: Use build_name if set

### DIFF
--- a/squad_client/commands/submit_tuxbuild.py
+++ b/squad_client/commands/submit_tuxbuild.py
@@ -50,6 +50,7 @@ tuxbuild_schema = {
             },
         },
         "required": [
+            "build_name",
             "download_url",
             "build_status",
             "git_describe",
@@ -61,6 +62,7 @@ tuxbuild_schema = {
 }
 
 ALLOWED_METADATA = [
+    "build_name",
     "download_url",
     "duration",
     "git_describe",
@@ -117,8 +119,10 @@ class SubmitTuxbuildCommand(SquadClientCommand):
 
         return builds
 
-    def _get_test_name(self, kconfig, toolchain):
-        if len(kconfig[1:]):
+    def _get_test_name(self, kconfig, toolchain, build_name):
+        if build_name:
+            kconfig_hash = build_name
+        elif len(kconfig[1:]):
             kconfig_hash = "%s-%s" % (
                 kconfig[0],
                 hashlib.sha1(json.dumps(kconfig[1:]).encode()).hexdigest()[0:8],
@@ -146,8 +150,9 @@ class SubmitTuxbuildCommand(SquadClientCommand):
             description = build["git_describe"]
             kconfig = build["kconfig"]
             toolchain = build["toolchain"]
+            build_name = build["build_name"]
             warnings_count = build["warnings_count"]
-            test_name = self._get_test_name(kconfig, toolchain)
+            test_name = self._get_test_name(kconfig, toolchain, build_name)
             test_status = build["build_status"]
             duration = build["duration"]
 

--- a/tests/data/submit/tuxbuild/build.json
+++ b/tests/data/submit/tuxbuild/build.json
@@ -1,6 +1,7 @@
 [
     {
         "build_key": "t8NSUfTBZiSPbBVaXLH7kw",
+        "build_name": "gcc-9-lkftconfig",
         "build_status": "pass",
         "client_token": "3cffcab5-aaf8-446d-8dec-861da6814788",
         "download_url": "https://builds.tuxbuild.com/t8NSUfTBZiSPbBVaXLH7kw/",
@@ -30,6 +31,7 @@
     },
     {
         "build_key": "B3TECkH4_1X9yKoWOPIhew",
+        "build_name": "gcc-9-lkftconfig",
         "build_status": "fail",
         "client_token": "32b482ac-2cc1-4f68-bf73-cc9f780b72cf",
         "download_url": "https://builds.tuxbuild.com/B3TECkH4_1X9yKoWOPIhew/",
@@ -58,6 +60,7 @@
     },
     {
         "build_key": "B3TECkH4_1X9yKoWOPIhed",
+        "build_name": "gcc-9-lkftconfig",
         "build_status": "fail",
         "client_token": "32b482ac-2cc1-4f68-bf73-cc9f780b72cf",
         "download_url": "https://builds.tuxbuild.com/B3TECkH4_1X9yKoWOPIhew/",

--- a/tests/test_submit_tuxbuild.py
+++ b/tests/test_submit_tuxbuild.py
@@ -84,6 +84,7 @@ class SubmitTuxbuildCommandTest(unittest.TestCase):
             'download_url': urls,
             'duration': 541,
             'toolchain': 'gcc-9',
+            'build_name': "gcc-9-lkftconfig",
         }
         for expected_key in expected_metadata.keys():
             self.assertEqual(expected_metadata[expected_key], getattr(build.metadata, expected_key))
@@ -110,6 +111,7 @@ class SubmitTuxbuildCommandTest(unittest.TestCase):
             'download_url': url,
             'duration': 541,
             'toolchain': 'gcc-9',
+            'build_name': "gcc-9-lkftconfig",
         }
         for expected_key in expected_metadata.keys():
             self.assertEqual(expected_metadata[expected_key], getattr(build.metadata, expected_key))


### PR DESCRIPTION
If a build has a `build_name` defined by Tuxbuild (originally from `tuxsuite build --build-name NAME`, then use that as the name for the kernel configuration that identifies the build.