### PR TITLE
commands: submit_tuxbuild: drop duplicate names

### DIFF
--- a/squad_client/commands/submit_tuxbuild.py
+++ b/squad_client/commands/submit_tuxbuild.py
@@ -63,8 +63,6 @@ tuxbuild_schema = {
 ALLOWED_METADATA = [
     "download_url",
     "duration",
-    "git_branch",
-    "git_commit",
     "git_describe",
     "git_ref",
     "git_repo",
@@ -72,7 +70,6 @@ ALLOWED_METADATA = [
     "git_short_log",
     "kconfig",
     "kernel_version",
-    "make_kernelversion",
 ]
 
 
@@ -96,19 +93,9 @@ class SubmitTuxbuildCommand(SquadClientCommand):
     def _build_metadata(self, build):
         metadata = {k: v for k, v in build.items() if k in ALLOWED_METADATA}
 
-        # We expect git_commit, but tuxmake calls it git_sha
-        metadata.update({"git_commit": metadata.get("git_sha")})
-
-        # We expect `git_branch`, but tuxmake calls it `git_ref`
-        # `git_ref` will sometimes be null
-        metadata.update({"git_branch": metadata.get("git_ref")})
-
         # If `git_ref` is null, use `KERNEL_BRANCH` from the CI environment
-        if metadata.get("git_branch") is None:
-            metadata.update({"git_branch": os.getenv("KERNEL_BRANCH")})
-
-        # We expect `make_kernelversion`, but tuxmake calls it `kernel_version`
-        metadata.update({"make_kernelversion": metadata.get("kernel_version")})
+        if metadata.get("git_ref") is None:
+            metadata.update({"git_ref": os.getenv("KERNEL_BRANCH")})
 
         # add config file to the metadata
         metadata["config"] = urlparse.urljoin(metadata.get('download_url'), "config")

--- a/tests/data/submit/tuxbuild/build.json
+++ b/tests/data/submit/tuxbuild/build.json
@@ -9,7 +9,7 @@
         "git_describe": "next-20201021",
         "git_repo": "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
         "git_sha": "5302568121ba345f5c22528aefd72d775f25221e",
-        "git_ref": null,
+        "git_ref": "master",
         "git_short_log": "5302568121ba (\"Add linux-next specific files for 20201021\")",
         "kconfig": [
             "defconfig",
@@ -38,7 +38,7 @@
         "git_describe": "next-20201021",
         "git_repo": "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
         "git_sha": "5302568121ba345f5c22528aefd72d775f25221e",
-        "git_ref": null,
+        "git_ref": "master",
         "git_short_log": "5302568121ba (\"Add linux-next specific files for 20201021\")",
         "kconfig": [
             "defconfig",
@@ -66,7 +66,7 @@
         "git_describe": "v4.4.4",
         "git_repo": "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
         "git_sha": "5302568121ba345f5c22528aefd72d775f25221e",
-        "git_ref": null,
+        "git_ref": "master",
         "git_short_log": "5302568121ba (\"Add linux-next specific files for 20201021\")",
         "kconfig": [
             "defconfig",

--- a/tests/data/submit/tuxbuild/buildset.json
+++ b/tests/data/submit/tuxbuild/buildset.json
@@ -9,7 +9,7 @@
         "git_describe": "next-20201030",
         "git_repo": "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
         "git_sha": "4e78c578cb987725eef1cec7d11b6437109e9a49",
-        "git_ref": null,
+        "git_ref": "master",
         "git_short_log": "4e78c578cb98 (\"Add linux-next specific files for 20201030\")",
         "kconfig": [
             "allnoconfig"
@@ -31,7 +31,7 @@
         "git_describe": "next-20201030",
         "git_repo": "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
         "git_sha": "4e78c578cb987725eef1cec7d11b6437109e9a49",
-        "git_ref": null,
+        "git_ref": "master",
         "git_short_log": "4e78c578cb98 (\"Add linux-next specific files for 20201030\")",
         "kconfig": [
             "tinyconfig"
@@ -53,7 +53,7 @@
         "git_describe": "next-20201030",
         "git_repo": "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
         "git_sha": "4e78c578cb987725eef1cec7d11b6437109e9a49",
-        "git_ref": null,
+        "git_ref": "master",
         "git_short_log": "4e78c578cb98 (\"Add linux-next specific files for 20201030\")",
         "kconfig": [
             "x86_64_defconfig"

--- a/tests/test_submit_tuxbuild.py
+++ b/tests/test_submit_tuxbuild.py
@@ -74,14 +74,11 @@ class SubmitTuxbuildCommandTest(unittest.TestCase):
         configs = [url + "config" for url in urls]
         expected_metadata = {
             'git_repo': "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
-            'git_ref': None,
-            'git_commit': "5302568121ba345f5c22528aefd72d775f25221e",
+            'git_ref': "master",
             'git_sha': "5302568121ba345f5c22528aefd72d775f25221e",
             'git_short_log': '5302568121ba ("Add linux-next specific files for 20201021")',
             'git_describe': "next-20201021",
             'kconfig': [base_kconfig + ["CONFIG_ARM64_MODULE_PLTS=y"], base_kconfig + ["CONFIG_IGB=y", "CONFIG_UNWINDER_FRAME_POINTER=y"]],
-            'git_branch': os.environ.get("KERNEL_BRANCH"),
-            'make_kernelversion': "5.9.0",
             'kernel_version': "5.9.0",
             'config': configs,
             'download_url': urls,
@@ -102,14 +99,11 @@ class SubmitTuxbuildCommandTest(unittest.TestCase):
         config = url + "config"
         expected_metadata = {
             'git_repo': "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
-            'git_ref': None,
-            'git_commit': "5302568121ba345f5c22528aefd72d775f25221e",
+            'git_ref': "master",
             'git_sha': "5302568121ba345f5c22528aefd72d775f25221e",
             'git_short_log': '5302568121ba ("Add linux-next specific files for 20201021")',
             'git_describe': "v4.4.4",
             'kconfig': base_kconfig + ["CONFIG_ARM64_MODULE_PLTS=y"],
-            'git_branch': os.environ.get("KERNEL_BRANCH"),
-            'make_kernelversion': "5.9.0",
             'kernel_version': "5.9.0",
             'config': config,
             'download_url': url,
@@ -165,14 +159,11 @@ class SubmitTuxbuildCommandTest(unittest.TestCase):
         configs = [url + "config" for url in urls]
         expected_metadata = {
             'git_repo': "https://gitlab.com/Linaro/lkft/mirrors/next/linux-next",
-            'git_ref': None,
-            'git_commit': "4e78c578cb987725eef1cec7d11b6437109e9a49",
+            'git_ref': "master",
             'git_sha': "4e78c578cb987725eef1cec7d11b6437109e9a49",
             'git_short_log': '4e78c578cb98 ("Add linux-next specific files for 20201030")',
             'git_describe': "next-20201030",
             'kconfig': [['allnoconfig'], ['tinyconfig'], ['x86_64_defconfig']],
-            'git_branch': os.environ.get("KERNEL_BRANCH"),
-            'make_kernelversion': "5.10.0-rc1",
             'kernel_version': "5.10.0-rc1",
             'config': configs,
             'download_url': urls,


### PR DESCRIPTION
Drop names that have been made up, use the names that tuxsuite provides
for us. Use 'git_sha' instead of 'git_commit', 'git_ref' instead of
'git_branch' and use 'kernel_version' instead of
'make_kernelversion'.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>