### PR TITLE
Class variables should not be mutable

### DIFF
--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -599,8 +599,8 @@ class TestRun(SquadObject):
         objects = self.__fill__(TestRunMetadata, [new_metadata])
         self.__metadata__ = first(objects)
 
-    test_suites = []
-    metric_suites = []
+    test_suites = None
+    metric_suites = None
 
     def bucket_metric_and_test_suites(self):
         all_tests = self.tests()
@@ -614,8 +614,8 @@ class TestRun(SquadObject):
                     test_suite.add_test(test)
 
         all_metrics = self.metrics()
+        self.metric_suites = []
         if len(all_metrics):
-            self.metric_suites = []
             for suite_name, metrics in groupby(sorted(all_metrics.values(), key=lambda m: m.name), lambda m: parse_metric_name(m.name)[0]):
                 metric_suite = MetricSuite()
                 metric_suite.name = suite_name

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -434,9 +434,12 @@ class Build(SquadObject):
 
         return testruns
 
-    __tests__ = {}
+    __tests__ = None
 
     def tests(self, count=ALL, **filters):
+        if self.__tests__ is None:
+            self.__tests__ = {}
+
         filters['count'] = count
         filters_str = str(OrderedDict(filters))
         if self.__tests__.get(filters_str) is None:
@@ -444,9 +447,12 @@ class Build(SquadObject):
             self.__tests__[filters_str] = self.__fetch__(Test, filters, count, endpoint=endpoint)
         return self.__tests__[filters_str]
 
-    __metrics__ = {}
+    __metrics__ = None
 
     def metrics(self, count=ALL, **filters):
+        if self.__metrics__ is None:
+            self.__metrics__ = {}
+
         filters['count'] = count
         filters_str = str(OrderedDict(filters))
         if self.__metrics__.get(filters_str) is None:

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -515,7 +515,7 @@ class TestJob(SquadObject):
 
 class MetricSuite:
     name = ''
-    __metrics__ = {}
+    __metrics__ = None
 
     def add_metric(self, metric):
         if self.__metrics__ is None:

--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -518,8 +518,8 @@ class MetricSuite:
     __metrics__ = {}
 
     def add_metric(self, metric):
-        if self.__metric__ is None:
-            self.__metric__ = {}
+        if self.__metrics__ is None:
+            self.__metrics__ = {}
         self.__metrics__[metric.id] = metric
 
     @property

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -98,9 +98,11 @@ class BuildTest(unittest.TestCase):
 
     def setUp(self):
         self.build = first(Squad().builds(version='my_build'))
+        self.build2 = first(Squad().builds(version='my_build2'))
 
     def test_basic(self):
         self.assertTrue(self.build is not None)
+        self.assertTrue(self.build2 is not None)
 
     def test_build_metadata(self):
         metadata = self.build.metadata
@@ -125,6 +127,13 @@ class BuildTest(unittest.TestCase):
         tests = self.build.tests(environment__slug='mynonexistentenv').values()
         self.assertEqual(0, len(tests))
 
+    def test_build_tests_change_cache_on_different_builds(self):
+        tests = self.build.tests(environment__slug='my_env').values()
+        self.assertEqual(4, len(tests))
+
+        tests = self.build2.tests(environment__slug='my_env').values()
+        self.assertEqual(0, len(tests))
+
     def test_build_metrics(self):
         tests = self.build.metrics().values()
         self.assertEqual(1, len(tests))
@@ -143,6 +152,13 @@ class BuildTest(unittest.TestCase):
 
         tests = self.build.metrics(environment__slug='mynonexistentenv').values()
         self.assertEqual(0, len(tests))
+
+    def test_build_metrics_change_cache_on_different_builds(self):
+        metrics = self.build.metrics(environment__slug='my_env').values()
+        self.assertEqual(1, len(metrics))
+
+        metrics = self.build2.metrics(environment__slug='my_env').values()
+        self.assertEqual(0, len(metrics))
 
 
 class TestRunTest(unittest.TestCase):


### PR DESCRIPTION
[core: models: fix initialization of class variables](https://github.com/Linaro/squad-client/pull/155/commits/217d59a282e23df16836a0c6b6ef5f54ee4976c2) 

Initialize class variables with None and then set them to a mutable type
when the instance calls a method.

If you initialize a class variable with a mutable type, it will be
shared amonst all instances of the class, rather than being instance
specific.

This means a change to that variable in one instance will affect all
other instances.

https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables

"The concept of class-variable and instance-variable is fine till the
point where you use mutable objects".

Suggested-by: Charles Oliveira <charles.oliveira@linaro.org>

Signed-off-by: Justin Cook <justin.cook@linaro.org>