### PR TITLE
core: models: query project testjobs

### DIFF
--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -389,6 +389,10 @@ class Project(SquadObject):
         filters.update({'project': self.id})
         return self.__fetch__(MetricThreshold, filters, count)
 
+    def testjobs(self, count=DEFAULT_COUNT, **filters):
+        filters.update({'target': self.id})
+        return self.__fetch__(TestJob, filters, count)
+
     def __repr__(self):
         return self.slug
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -53,7 +53,7 @@ RecordTestRunStatus()(testrun_no_metadata)
 mci.Backend.objects.create(name='my_tuxsuite_backend', implementation_type='tuxsuite')
 
 backend = mci.Backend.objects.create(name='my_backend', implementation_type='lava')
-testjob = testrun.test_jobs.create(backend=backend, target=project, target_build=build)
+testjob = testrun.test_jobs.create(backend=backend, target=project, target_build=build, name='my_testjob')
 
 emailtemplate = m.EmailTemplate.objects.create(name='my_emailtemplate')
 suitemetadata = m.SuiteMetadata.objects.create(name='my_suitemetadata')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -216,6 +216,12 @@ class ProjectTest(unittest.TestCase):
         threshold = first(thresholds)
         self.assertEqual(threshold.name, 'my-threshold')
 
+    def test_project_testjobs(self):
+        testjobs = self.project.testjobs()
+        self.assertEqual(1, len(testjobs))
+        testjob = first(testjobs)
+        self.assertEqual(testjob.name, 'my_testjob')
+
     def test_compare_builds_from_same_project(self):
         # tests
         comparison = self.project.compare_builds(self.build2.id, self.build.id)


### PR DESCRIPTION
This patch will allow fetching jobs from project. It'll help querying builds that use some specific filter in their testjobs, such as backend type (lava or tuxsuite).