### PR TITLE
commands: download_results: add command to download test results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  DJANGO_WATCHMAN_TIMEOUT: 30
+
 jobs:
 
   lint:

--- a/squad_client/commands/download_results.py
+++ b/squad_client/commands/download_results.py
@@ -1,0 +1,73 @@
+from squad_client import logging
+from squad_client.core.command import SquadClientCommand
+from squad_client.core.models import Squad
+from squad_client.shortcuts import download_tests, get_build
+
+
+logger = logging.getLogger(__name__)
+
+
+class DownloadResultsCommand(SquadClientCommand):
+    command = "download-results"
+    help_text = "download test results from SQUAD"
+
+    def register(self, subparser):
+        parser = super(DownloadResultsCommand, self).register(subparser)
+        parser.add_argument(
+            "--group", help="SQUAD group", required=True
+        )
+        parser.add_argument(
+            "--project", help="SQUAD project", required=True
+        )
+        parser.add_argument(
+            "--build", help="Build version. Exemples: my-build-version. Or pre-defined build aliases: latest and latest-finished", required=True,
+        )
+        parser.add_argument(
+            "--environment", help="Test environment"
+        )
+        parser.add_argument(
+            "--suite", help="Test suite"
+        )
+        parser.add_argument(
+            "--filename", help="Name of the output file where results will be written"
+        )
+        parser.add_argument(
+            "--debug",
+            action='store_true',
+            help="Set debug mode"
+        )
+
+    def run(self, args):
+        if args.debug:
+            logger.setLevel(logging.DEBUG)
+
+        group = Squad().group(args.group)
+        if group is None:
+            logger.error(f"Group \"{args.group}\"not found")
+            return False
+
+        project = group.project(args.project)
+        if project is None:
+            logger.error(f"Project \"{group.slug}/{args.project}\" not found")
+            return False
+
+        build = get_build(args.build, project)
+        if build is None:
+            logger.error(f"Build \"{group.slug}/{project.slug}/{args.build}\" not found")
+            return False
+
+        environment = None
+        if args.environment:
+            environment = project.environment(args.environment)
+
+        suite = None
+        if args.suite:
+            suite = project.suite(args.suite)
+
+        return download_tests(
+            project,
+            build,
+            environment=environment,
+            suite=suite,
+            output_filename=args.filename,
+        )

--- a/squad_client/core/api.py
+++ b/squad_client/core/api.py
@@ -108,7 +108,7 @@ class SquadApi:
             kwargs['params'] = params
 
         url = '%s%s' % (SquadApi.url, endpoint if endpoint[0] != '/' else endpoint[1:])
-        logger.debug('%s %s' % (method, url))
+        logger.debug('%s %s (%s)' % (method, url, kwargs))
 
         if SquadApi.headers:
             kwargs['headers'] = SquadApi.headers


### PR DESCRIPTION
```bash
$ export SQUAD_HOST=https://qa-reports.linaro.org/
$ export SQUAD_TOKEN=<token>
$ ./manage.py \
    download-results \
    --group "lkft" \
    --project "linux-stable-rc-linux-5.19.y" \
    --build v5.19.4
[INFO] Downloading test results for lkft/linux-stable-rc-linux-5.19.y/v5.19.4/(all envs)/(all suites) to v5.19.4.txt

$ time ./manage.py \
    download-results \
    --group "lkft" \
    --project "linux-stable-rc-linux-5.19.y" \
    --build v5.19.3
[INFO] Downloading test results for lkft/linux-stable-rc-linux-5.19.y/v5.19.3/(all envs)/(all suites) to v5.19.3.txt

real	2m16.585s
user	0m4.447s
sys	0m0.187s

$ diff -u v5.19.3.txt v5.19.4.txt > diff.txt
```

Files [v5.19.3.txt](https://github.com/Linaro/squad-client/files/9434773/v5.19.3.txt) and [v5.19.4.txt](https://github.com/Linaro/squad-client/files/9434777/v5.19.4.txt) contain all tests of these two builds, and diff'ing them gets you [diff.txt](https://github.com/Linaro/squad-client/files/9434783/diff.txt).

Note that the diff is huge because how test-names for tuxsuite tests are always different (this is a problem for later).

Daniel, this is far from looking good in squad UI, but at least it can get your builds compared with reasonable waiting time (~5min to download tests for both builds)