### PR TITLE
models.py: add started_at ended_at for TestJob

### DIFF
--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -533,7 +533,7 @@ class TestJob(SquadObject):
              'submitted_at', 'fetched_at', 'submitted', 'fetched', 'fetch_attempts',
              'last_fetch_attempt', 'failure', 'can_resubmit', 'resubmitted_count',
              'job_id', 'job_status', 'backend', 'testrun', 'target', 'target_build',
-             'parent_job']
+             'parent_job', 'started_at', 'ended_at']
 
     def submit(self):
         squad = Squad()


### PR DESCRIPTION
so that we could get the job duration with them

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>