### PR TITLE
squad_client: shortcuts: fix regex

### DIFF
--- a/squad_client/shortcuts.py
+++ b/squad_client/shortcuts.py
@@ -255,7 +255,7 @@ def get_build(build_version, project):
     """
 
     # This regex HAS to match
-    regex = r'^(.*?)([-+]\d+)?$'
+    regex = r'^(.*?(?:-\d{8})?)([-+]\d+)?$'
     matches = re.search(regex, build_version)
     if matches is None:
         logger.error(f'Unknown behavior: {regex} is supposed to match any string > 0, including build version {build_version}')


### PR DESCRIPTION
Make it possible to pass a date like next-20221220 as a build, and get_build() wont think its the build 'next' minus '20221220' builds.

Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Suggested-by: Charles Oliveria <charles.oliveria@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>