### PR TITLE
squad_client/core/models.py: Add attachment_urls property to TestRuns

### DIFF
--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -638,7 +638,7 @@ class TestRun(SquadObject):
              'job_id', 'job_status', 'job_url', 'resubmit_url',
              'data_processed', 'status_recorded', 'build',
              'environment', 'attachments']
-    attachments = None
+
     log = None
 
     __tests__ = None
@@ -689,6 +689,29 @@ class TestRun(SquadObject):
 
     test_suites = None
     metric_suites = None
+
+    __attachments__ = None
+
+    @property
+    def attachments(self):
+        if self.__attachments__ is None:
+            return None
+        else:
+            return self.__attachments__
+
+    @attachments.setter
+    def attachments(self, attachments):
+        self.__attachments__ = attachments
+
+    @property
+    def attachment_urls(self):
+        # Returns the list of attachment urls from the TestRun
+        attachment_urls = []
+        if self.attachments is not None:
+            for attachment in self.attachments:
+                attachment_urls.append(attachment['download_url'])
+
+        return attachment_urls
 
     def bucket_metric_and_test_suites(self):
         all_tests = self.tests()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -50,6 +50,17 @@ RecordTestRunStatus()(testrun)
 testrun_no_metadata = build.test_runs.create(environment=environment)
 RecordTestRunStatus()(testrun_no_metadata)
 
+testrun_attachments = build.test_runs.create(environment=environment)
+filename1 = 'foo1.txt'
+contents1 = b'attachment file 1 content'
+attachment1 = testrun_attachments.attachments.create(filename=filename1, length=len(contents1))
+attachment1.save_file(filename1, contents1)
+
+filename2 = 'foo2.txt'
+contents2 = b'attachment file 2 content'
+attachment2 = testrun_attachments.attachments.create(filename=filename2, length=len(contents2))
+attachment2.save_file(filename2, contents2)
+
 mci.Backend.objects.create(name='my_tuxsuite_backend', implementation_type='tuxsuite')
 
 backend = mci.Backend.objects.create(name='my_backend', implementation_type='lava')


### PR DESCRIPTION
Add a property `attachement_urls` to TestRuns that returns the download URLs for a given TestRun.