### PR TITLE
core/models.py: add TestRunAttachment class

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,4 @@
 import unittest
-import requests
 
 from . import settings
 from squad_client.core.api import SquadApi
@@ -198,21 +197,15 @@ class TestRunTest(unittest.TestCase):
 
     def test_testrun_attachment(self):
         """Test that created attachment entries can be retrieved from the TestRun."""
-        self.assertTrue(self.testrun_attachment.attachments is not None)
-        self.assertTrue(len(self.testrun_attachment.attachments) == 2)
-
-    def test_testrun_attachment_urls(self):
-        """Test that created attachment entries can be accessed via the attachment_urls TestRun property."""
-        attachment_urls = self.testrun_attachment.attachment_urls
-        self.assertTrue(attachment_urls is not None)
-        self.assertTrue(len(attachment_urls) == 2)
+        attachments = self.testrun_attachment.attachments
+        self.assertTrue(attachments is not None)
+        self.assertTrue(len(attachments) == 2)
 
         attachment_contents = []
         expected_attachment_contents = [b'attachment file 1 content', b'attachment file 2 content']
 
-        for attachment_url in attachment_urls:
-            request = requests.get(attachment_url)
-            attachment_contents.append(request.content)
+        for attachment in attachments:
+            attachment_contents.append(attachment.read())
 
         self.assertEqual(attachment_contents, expected_attachment_contents)
 


### PR DESCRIPTION
This will be used to help handling testrun attachments. It wraps the feature of downloading it inside a `read` function.