### PR TITLE
squad_client/core/models: Fix TestRun init function

### DIFF
--- a/squad_client/core/models.py
+++ b/squad_client/core/models.py
@@ -667,14 +667,14 @@ class TestRun(SquadObject):
 
     log = None
 
-    def __init__(self):
-        super().__init__(self)
+    def __init__(self, _id=None):
         self.__attachments__ = []
         self.__metadata__ = None
         self.__metrics__ = None
         self.__tests__ = None
         self.test_suites = None
         self.metric_suites = None
+        super().__init__(_id)
 
     def add_test(self, test):
         if self.__tests__ is None:


### PR DESCRIPTION
The feature that allows a TestRun ID to be passed to the TestRun constructor was accidentally removed during a recent update (https://github.com/Linaro/squad-client/pull/171)

As a result, the TestRun init function was missing option to initialise a TestRun object by an existing TestRun ID.

Add ID as an optional parameter to the TestRun init function to restore this functionality.

Move the `super().__init__(_id)` so it is called after the default values of the object's members have been initialised to None or empty. This means that the data will be filled in if an ID is provided and initialised to None or [] if no ID is provided.